### PR TITLE
💎 Refactor: Response 관련 Package 구조 변경

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/error/ErrorCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.bluehair.hanghaefinalproject.common.success;
+package com.bluehair.hanghaefinalproject.common.response.error;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,11 +7,11 @@ import org.springframework.http.HttpStatus;
 // Domain이 커지게 될 경우, 해당 객체를 Abstract로 선언 후 Domain별 extend
 @Getter
 @AllArgsConstructor
-public enum SucessCode {
-    // Member
-    SIGNUP_MEMBER(HttpStatus.OK, "회원 가입 성공", 2000);
+public enum ErrorCode {
+    INVALID_EMAIL(HttpStatus.OK, "유효하지 않은 이메일입니다.", 4041);
 
     private final HttpStatus httpStatus;
     private final String message;
     private final Integer customHttpStatusCode;
+
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/error/ErrorResponse.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.bluehair.hanghaefinalproject.common.exception;
+package com.bluehair.hanghaefinalproject.common.response.error;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SuccessResponse.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SuccessResponse.java
@@ -1,4 +1,4 @@
-package com.bluehair.hanghaefinalproject.common.success;
+package com.bluehair.hanghaefinalproject.common.response.success;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
@@ -8,15 +8,15 @@ import org.springframework.http.ResponseEntity;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Response<T> {
+public class SuccessResponse<T> {
     private final Integer customHttpStatus;
     private final String message;
     private T data;
 
-    public static<T> ResponseEntity<Response<T>> toResponseEntity(SucessCode sucessCode, T data){
+    public static<T> ResponseEntity<SuccessResponse<T>> toResponseEntity(SucessCode sucessCode, T data){
         return ResponseEntity
                 .status(sucessCode.getHttpStatus())
-                .body(Response.<T>builder()
+                .body(SuccessResponse.<T>builder()
                         .customHttpStatus(sucessCode.getCustomHttpStatusCode())
                         .message(sucessCode.getMessage())
                         .data(data)

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
@@ -1,4 +1,4 @@
-package com.bluehair.hanghaefinalproject.common.exception;
+package com.bluehair.hanghaefinalproject.common.response.success;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,11 +7,11 @@ import org.springframework.http.HttpStatus;
 // Domain이 커지게 될 경우, 해당 객체를 Abstract로 선언 후 Domain별 extend
 @Getter
 @AllArgsConstructor
-public enum ErrorCode {
-    INVALID_EMAIL(HttpStatus.OK, "유효하지 않은 이메일입니다.", 4041);
+public enum SucessCode {
+    // Member
+    SIGNUP_MEMBER(HttpStatus.OK, "회원 가입 성공", 2000);
 
     private final HttpStatus httpStatus;
     private final String message;
     private final Integer customHttpStatusCode;
-
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/controller/MemberController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.bluehair.hanghaefinalproject.member.controller;
 
-import com.bluehair.hanghaefinalproject.common.success.Response;
-import com.bluehair.hanghaefinalproject.common.success.SucessCode;
+import com.bluehair.hanghaefinalproject.common.response.success.SuccessResponse;
+import com.bluehair.hanghaefinalproject.common.response.success.SucessCode;
 import com.bluehair.hanghaefinalproject.member.service.MemberService;
 
 import io.swagger.annotations.ApiOperation;
@@ -28,6 +28,6 @@ public class MemberController {
     @GetMapping("/test")
     public ResponseEntity<?> test(){
         memberService.test();
-        return Response.toResponseEntity(SucessCode.SIGNUP_MEMBER, null);
+        return SuccessResponse.toResponseEntity(SucessCode.SIGNUP_MEMBER, null);
     }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/exception/InvalidSignUpRequestException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/exception/InvalidSignUpRequestException.java
@@ -1,6 +1,6 @@
 package com.bluehair.hanghaefinalproject.member.exception;
 
-import com.bluehair.hanghaefinalproject.common.exception.ErrorCode;
+import com.bluehair.hanghaefinalproject.common.response.error.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/exception/InvalidSignUpRequestHandler.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/exception/InvalidSignUpRequestHandler.java
@@ -1,6 +1,6 @@
 package com.bluehair.hanghaefinalproject.member.exception;
 
-import com.bluehair.hanghaefinalproject.common.exception.ErrorResponse;
+import com.bluehair.hanghaefinalproject.common.response.error.ErrorResponse;
 import com.bluehair.hanghaefinalproject.member.controller.MemberController;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.bluehair.hanghaefinalproject.member.service;
 
-import com.bluehair.hanghaefinalproject.common.exception.ErrorCode;
+import com.bluehair.hanghaefinalproject.common.response.error.ErrorCode;
 import com.bluehair.hanghaefinalproject.member.entity.Member;
 import com.bluehair.hanghaefinalproject.member.exception.InvalidSignUpRequestException;
 import com.bluehair.hanghaefinalproject.member.repository.MemberRepository;


### PR DESCRIPTION
Package 구조 변경입니다.
일관성을 위해 Response Package 내부에 Success / Error로 나누고, Exception Response -> ErrorResponse로 수정하였습니다.

## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Response 관련 Package 구조 변경하였습니다. 변경 내용은 다음과 같습니다.
### 1. Response Package 내부 구성
Error / Success 패키지로 구분하였습니다.
### 2. 각 패키지별 객체
1. Error : ErrorCode, ErrorResponse
2. Success : SuccessCode, SuccessResponse

## 작업사항
- 패키지 분리
- 패키지 내부 객체 이름 변경


## 변경로직
- 없음
