### PR TITLE
✨ Feat : 게시글 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestRepository.java
@@ -3,6 +3,9 @@ package com.bluehair.hanghaefinalproject.collaboRequest.repository;
 import com.bluehair.hanghaefinalproject.collaboRequest.entity.CollaboRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CollaboRequestRepository extends JpaRepository<CollaboRequest, Long> {
 
+    List<CollaboRequest> findAllByPostId(Long id);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
@@ -19,6 +19,7 @@ public enum SucessCode {
     // Post
     INFO_POST(HttpStatus.OK, "상세 게시글 조회 성공", 2000),
     CREATE_POST(HttpStatus.OK, "게시글 작성 성공", 2000),
+    MAIN_POST(HttpStatus.OK, "게시글 전체 조회 성공",2000),
 
     //CollaboRequest
     COLLABO_REQUEST(HttpStatus.OK, "콜라보 리퀘스트 성공", 2000);

--- a/src/main/java/com/bluehair/hanghaefinalproject/music/repository/MusicRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/repository/MusicRepository.java
@@ -4,4 +4,5 @@ import com.bluehair.hanghaefinalproject.music.entity.Music;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MusicRepository extends JpaRepository<Music, Long> {
+    Music findByCollaboRequest_Id(Long id);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/controller/PostController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/controller/PostController.java
@@ -4,17 +4,20 @@ import com.bluehair.hanghaefinalproject.common.response.success.SuccessResponse;
 import com.bluehair.hanghaefinalproject.post.dto.requestDto.RequestPostDto;
 import com.bluehair.hanghaefinalproject.post.service.PostService;
 
+import com.bluehair.hanghaefinalproject.security.CustomUserDetails;
 import io.swagger.annotations.ApiOperation;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
 
 import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.CREATE_POST;
 import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.INFO_POST;
+import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.MAIN_POST;
 
 @RestController
 @RequestMapping("/api/post")
@@ -25,9 +28,9 @@ public class PostController {
 
     @ApiOperation(value = "작성", notes = "게시글 작성", response = SuccessResponse.class)
     @PostMapping
-    public ResponseEntity<?> createPost(@RequestBody RequestPostDto requestPostDto, @AuthenticationPrincipal UserDetails userDetails){
+    public ResponseEntity<?> createPost(@RequestBody RequestPostDto requestPostDto, @AuthenticationPrincipal CustomUserDetails userDetails){
 
-        postService.createPost(requestPostDto.toPostDto(), userDetails.getUsername());
+        postService.createPost(requestPostDto.toPostDto(), userDetails.getMember().getNickname());
 
         return SuccessResponse.toResponseEntity(CREATE_POST,null);
     }
@@ -37,6 +40,13 @@ public class PostController {
     public ResponseEntity<?> infoPost(@PathVariable Long postid){
 
         return SuccessResponse.toResponseEntity(INFO_POST,postService.infoPost(postid));
+    }
+
+    @ApiOperation(value = "조회", notes = "게시글 전체 조회", response = SuccessResponse.class)
+    @GetMapping("")
+    public ResponseEntity<?> mainPost(Pageable pageable){
+
+        return SuccessResponse.toResponseEntity(MAIN_POST,postService.mainPost(pageable));
     }
 
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/dto/serviceDto/MainPostDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/dto/serviceDto/MainPostDto.java
@@ -1,0 +1,28 @@
+package com.bluehair.hanghaefinalproject.post.dto.serviceDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MainPostDto {
+    private Long id;
+    private String title;
+    private Long viewCount;
+    private Long likeCount ;
+    private List<String> musicFileList;
+    private List<String> profileList;
+
+    @Builder
+    public MainPostDto(Long id, String  title, Long likeCount, Long viewCount, List<String> musicFileList
+                    ,List<String> profileList){
+        this.id = id;
+        this.title = title;
+        this.likeCount = likeCount;
+        this.viewCount = viewCount;
+        this.musicFileList = musicFileList;
+        this.profileList = profileList;
+    }
+
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/mapper/PostMapStruct.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/mapper/PostMapStruct.java
@@ -1,14 +1,18 @@
 package com.bluehair.hanghaefinalproject.post.mapper;
 
+import com.bluehair.hanghaefinalproject.post.dto.serviceDto.MainPostDto;
 import com.bluehair.hanghaefinalproject.post.dto.serviceDto.PostDto;
 import com.bluehair.hanghaefinalproject.post.entity.Post;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+import java.util.List;
+
+@Mapper(componentModel = "spring")
 public interface PostMapStruct {
     PostMapStruct POST_MAPPER = Mappers.getMapper(PostMapStruct.class);
     Post PostDtoToPost(PostDto postDto, String nickname);
-
+    MainPostDto PostToMainPostDto(Long id, String title, Long likeCount, Long viewCount,  List<String> musicFileList
+                                ,List<String> profileList);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/repository/PostRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/repository/PostRepository.java
@@ -1,13 +1,15 @@
 package com.bluehair.hanghaefinalproject.post.repository;
 
 import com.bluehair.hanghaefinalproject.post.entity.Post;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
 public interface PostRepository {
     Post save(Post post);
     Optional<Post> findById(Long postId);
-
+    List<Post> findAllByOrderByModifiedAtDesc(Pageable pageable);
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명

게시글 전체 조회 기능 구현 PR입니다.

게시글 작성자의 프로필 사진은 게시글 작성 API에서 먼저 프로필 사진을 넣어야하기 떄문에 추후에 추가해서 PR을 올릴 예정입니다.

구현하면서 어떤 것을 반환해야할지 API설계와 와이어프레임을 보면서 고민하여 작업하였습니다.

제외된 값 
{"isLiked",
"createdAt",
"modifiedAt",
"musicPart"}

isLiked는 추후에 좋아요 기능이 완성된 뒤에 테스트하며 추가할 예정입니다.

createdAt, modifiedAt은 일단 와이어프레임상 작성일이 따로 표시되지 않아 보내지 않았습니다.

화면 구조상 해당 게시글의 오디오 파일을 전체 재생합니다. 때문에 musicPart를 표기하는 것은 조금 이상하다고 생각이 들었습니다.
( 와이어 프레임 상으로도 표기되지 않는 것 같습니다. )

개인적으로 불필요한 데이터를 보내는 것은 좋지 않다고 느끼기 때문에 의견 있으시면 자유롭게 말씀해주세요!
물론 화면 표기상 필요하다면 바로 추가하겠습니다!

그리고 콜라보 리퀘스트 요청자의 프로필 사진 중복제거 처리 로직도 필요해보였습니다. 
죄송하지만 당장은 중복제거를 할 자신이 없어 다음 PR에 추가하도록 하겠습니다.

## 작업사항
게시글 전체 리스트를 조회하는 API를 구현하였습니다.

close #44 
