### PR TITLE
🐞 BugFix, ✨ Feat: @Schema 적용 오류 해결 및 Member Domain Swagger 설정

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SuccessResponse.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SuccessResponse.java
@@ -1,16 +1,21 @@
 package com.bluehair.hanghaefinalproject.common.response.success;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 
+@Schema(description = "요청 성공 시 ResponseDto")
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SuccessResponse<T> {
+    @Schema(description = "Custom Http 상태 코드", example = "2000")
     private final Integer customHttpStatus;
+    @Schema(description = "상태 메세지", example = "~기능 성공")
     private final String message;
+    @Schema(description = "반환 데이터")
     private T data;
 
     public static<T> ResponseEntity<SuccessResponse<T>> toResponseEntity(SucessCode sucessCode, T data){

--- a/src/main/java/com/bluehair/hanghaefinalproject/config/SwaggerConfig.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.bluehair.hanghaefinalproject.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
@@ -13,6 +14,7 @@ public class SwaggerConfig {
     @Bean
     public Docket api() {
         return new Docket(DocumentationType.OAS_30)
+                .ignoredParameterTypes(AuthenticationPrincipal.class)
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())
                 .select()

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/controller/MemberController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/controller/MemberController.java
@@ -5,11 +5,14 @@ import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestLoginDto;
 import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestSignUpDto;
 import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestValidateEmailDto;
 import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestValidateNicknameDto;
+import com.bluehair.hanghaefinalproject.member.dto.responseDto.ResponseMemberInfoDto;
 import com.bluehair.hanghaefinalproject.member.service.MemberService;
 
 import com.bluehair.hanghaefinalproject.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +33,7 @@ import static com.bluehair.hanghaefinalproject.common.response.success.SucessCod
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    @Tag(name = "Member")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "2000", description = "사용 가능한 이메일"),
             @ApiResponse(responseCode = "4091", description = "이메일 중복"),
@@ -41,7 +45,7 @@ public class MemberController {
         memberService.validateEmail(requestValidateEmailDto.toValidateEmailDto());
         return SuccessResponse.toResponseEntity(VALID_EMAIL, null);
     }
-
+    @Tag(name = "Member")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "2000", description = "사용 가능한 닉네임"),
             @ApiResponse(responseCode = "4092", description = "닉네임 중복"),
@@ -52,7 +56,7 @@ public class MemberController {
         memberService.validateNickname(requestValidateNicknameDto.toValidateNicknameDto());
         return SuccessResponse.toResponseEntity(VALID_NICKNAME, null);
     }
-
+    @Tag(name = "Member")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "2000", description = "회원 가입 성공"),
             @ApiResponse(responseCode = "4002", description = "유효하지 않은 비밀번호"),
@@ -65,6 +69,7 @@ public class MemberController {
         memberService.signUp(requestSignUpDto.toSignUpDto());
         return SuccessResponse.toResponseEntity(SIGNUP_MEMBER, null);
     }
+    @Tag(name = "Member")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "2000", description = "로그인 성공"),
             @ApiResponse(responseCode = "4003", description = "계정 정보 불일치")
@@ -75,17 +80,19 @@ public class MemberController {
         memberService.login(requestLoginDto.toLoginMemberDto(), response);
         return SuccessResponse.toResponseEntity(LOGIN_MEMBER, null);
     }
+    @Tag(name = "Member")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "2000", description = "회원 정보 반환 성공"),
+            @ApiResponse(responseCode = "2000", description = "회원 정보 반환 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
             @ApiResponse(responseCode = "4011", description = "AccessToken 존재하지 않음"),
             @ApiResponse(responseCode = "4013", description = "유효하지 않은 AccessToken"),
             @ApiResponse(responseCode = "4015", description = "만료된 AccessToken")
     })
     @Operation(summary = "회원 정보 반환", description = "토큰 분해 및 정보 반환")
     @GetMapping("/info")
-    public ResponseEntity<?> memberInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<SuccessResponse<ResponseMemberInfoDto>> memberInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return SuccessResponse.toResponseEntity(MEMBER_INFO, memberService.memberInfo(userDetails));
     }
+    @Tag(name = "Member")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "4011", description = "AccessToken 존재하지 않음"),
             @ApiResponse(responseCode = "4013", description = "유효하지 않은 AccessToken"),


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
### 1. @Schema 적용 오류
Swagger3.0에서 Generic Type을 @Schema를 사용해 Response 형식을 지정하기 위해서는, Unbounded를 사용하지 않고 세세하게 Reponse를 명시해주어야 한다. 이 때문에 다음과 같이 수정했다.
`ResponseEntity<?>` -> `ResponseEntity<SuccessResponse<ResponseMemberInfoDto>>`
### 2. @Tag 적용 오류
각 Method에도 @Tag 어노테이션을 사용해 각 메소드가 어떤 @Tag에 속해있는지 명시할 수 있도록 했다.
### 3. @AuthenticationPrincipal 파라미터 예외처리
Request Parameter 목록에서 `@AuthenticationPrincipal` 관련 Parameter를 제외했다.

## 작업사항
- 위와 같음.


## 변경로직
- 없음.
close #51, #31
