### PR TITLE
✨ Feat: 팔로우 기능 구현

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/error/ErrorCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/error/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(HttpStatus.OK, "중복된 이메일입니다.", 4091),
     DUPLICATED_NICKNAME(HttpStatus.OK, "중복된 닉네임입니다.", 4092),
     MEMBER_NOT_FOUND(HttpStatus.OK, "존재하지 않는 회원입니다.", 4041),
+    ALREADY_FOLLWED(HttpStatus.OK, "이미 팔로우한 회원입니다.", 4042),
+    ALREADY_UNFOLLWED(HttpStatus.OK, "이미 언팔로우한 회원입니다.", 4042),
 
     // JWT
     ACCESSTOKEN_NOT_EXIST(HttpStatus.OK, "Access Token이 존재하지 않습니다.", 4011),

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
@@ -13,6 +13,8 @@ public enum SucessCode {
     VALID_NICKNAME(HttpStatus.OK, "사용 가능한 닉네임", 2000),
     SIGNUP_MEMBER(HttpStatus.OK, "회원 가입 성공", 2000),
     LOGIN_MEMBER(HttpStatus.OK, "로그인 성공", 2000),
+    FOLLOW_MEMBER(HttpStatus.OK, "팔로우 성공", 2000),
+    UNFOLLOW_MEMBER(HttpStatus.OK, "언팔로우 성공", 2000),
     MEMBER_INFO(HttpStatus.OK, "사용자 정보 반환 성공", 2000),
     TOKEN_REISSUANCE(HttpStatus.OK, "토큰 재발행 성공", 2001),
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/config/SwaggerConfig.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.bluehair.hanghaefinalproject.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
@@ -15,6 +16,7 @@ public class SwaggerConfig {
     public Docket api() {
         return new Docket(DocumentationType.OAS_30)
                 .ignoredParameterTypes(AuthenticationPrincipal.class)
+                .ignoredParameterTypes(Pageable.class)
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())
                 .select()

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/controller/MemberController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/controller/MemberController.java
@@ -1,10 +1,7 @@
 package com.bluehair.hanghaefinalproject.member.controller;
 
 import com.bluehair.hanghaefinalproject.common.response.success.SuccessResponse;
-import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestLoginDto;
-import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestSignUpDto;
-import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestValidateEmailDto;
-import com.bluehair.hanghaefinalproject.member.dto.requestDto.RequestValidateNicknameDto;
+import com.bluehair.hanghaefinalproject.member.dto.requestDto.*;
 import com.bluehair.hanghaefinalproject.member.dto.responseDto.ResponseMemberInfoDto;
 import com.bluehair.hanghaefinalproject.member.service.MemberService;
 
@@ -82,12 +79,12 @@ public class MemberController {
     }
     @Tag(name = "Member")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "2000", description = "회원 정보 반환 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "2000", description = "회원 정보 반환 성공"),
             @ApiResponse(responseCode = "4011", description = "AccessToken 존재하지 않음"),
             @ApiResponse(responseCode = "4013", description = "유효하지 않은 AccessToken"),
             @ApiResponse(responseCode = "4015", description = "만료된 AccessToken")
     })
-    @Operation(summary = "회원 정보 반환", description = "토큰 분해 및 정보 반환")
+    @Operation(summary = "현재 접속 중인 회원 정보 반환", description = "토큰 분해 및 정보 반환")
     @GetMapping("/info")
     public ResponseEntity<SuccessResponse<ResponseMemberInfoDto>> memberInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return SuccessResponse.toResponseEntity(MEMBER_INFO, memberService.memberInfo(userDetails));
@@ -106,5 +103,26 @@ public class MemberController {
     public ResponseEntity<SuccessResponse<Object>> reissuance(HttpServletRequest request, HttpServletResponse response){
         memberService.tokenReissuance(request, response);
         return SuccessResponse.toResponseEntity(TOKEN_REISSUANCE, null);
+    }
+    @Tag(name = "Member")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "2000", description = "팔로우 성공"),
+            @ApiResponse(responseCode = "2000", description = "언팔로우 성공"),
+            @ApiResponse(responseCode = "4011", description = "AccessToken 존재하지 않음"),
+            @ApiResponse(responseCode = "4013", description = "유효하지 않은 AccessToken"),
+            @ApiResponse(responseCode = "4015", description = "만료된 AccessToken"),
+            @ApiResponse(responseCode = "4042", description = "이미 팔로우한 회원"),
+            @ApiResponse(responseCode = "4042", description = "이미 언팔로우한 회원")
+    })
+    @Operation(summary = "팔로우 기능", description = "Follow 시 isFollowed=false, Unfollow 시 isFollowed=true")
+    @PutMapping("/follow")
+    public ResponseEntity<SuccessResponse<Object>> follow(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                          @RequestBody RequestFollowDto requestFollowDto) {
+        if(requestFollowDto.getIsFollowed()){
+            memberService.doUnfollow(customUserDetails, requestFollowDto.toFollowDto());
+            return SuccessResponse.toResponseEntity(UNFOLLOW_MEMBER, null);
+        }
+        memberService.doFollow(customUserDetails, requestFollowDto.toFollowDto());
+        return SuccessResponse.toResponseEntity(FOLLOW_MEMBER, null);
     }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/dto/requestDto/RequestFollowDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/dto/requestDto/RequestFollowDto.java
@@ -1,0 +1,21 @@
+package com.bluehair.hanghaefinalproject.member.dto.requestDto;
+
+import com.bluehair.hanghaefinalproject.member.dto.serviceDto.FollowDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(description = "Follow 요청 DTO")
+@Getter
+public class RequestFollowDto {
+    @Schema(description = "팔로우 할 회원 닉네임", required = true, example = "test01")
+    private String myFollowingMemberNickname;
+
+    @Schema(description = "Follow 되어있는지 여부", required = true, example = "false")
+    private Boolean isFollowed;
+
+    public FollowDto toFollowDto() {
+        return FollowDto.builder()
+                .myFollowingMemberNickname(myFollowingMemberNickname)
+                .build();
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/dto/serviceDto/FollowDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/dto/serviceDto/FollowDto.java
@@ -1,0 +1,14 @@
+package com.bluehair.hanghaefinalproject.member.dto.serviceDto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FollowDto {
+    private String myFollowingMemberNickname;
+
+    @Builder
+    public FollowDto(String myFollowingMemberNickname) {
+        this.myFollowingMemberNickname = myFollowingMemberNickname;
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/entity/Follow.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/entity/Follow.java
@@ -1,0 +1,29 @@
+package com.bluehair.hanghaefinalproject.member.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Follow {
+    @EmbeddedId
+    private FollowCompositeKey id;
+
+    @MapsId("memberId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @MapsId("myFollowingId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member myFollowing;
+
+    public Follow(FollowCompositeKey id, Member member, Member myFollowing) {
+        this.id = id;
+        this.member = member;
+        this.myFollowing = myFollowing;
+    }
+
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/entity/FollowCompositeKey.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/entity/FollowCompositeKey.java
@@ -1,0 +1,21 @@
+package com.bluehair.hanghaefinalproject.member.entity;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor
+public class FollowCompositeKey implements Serializable {
+    @Column(nullable = false)
+    private Long memberId;
+    @Column(nullable = false)
+    private Long myFollowingId;
+
+    public FollowCompositeKey(Long memberId, Long myFollowingId) {
+        this.memberId = memberId;
+        this.myFollowingId = myFollowingId;
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/entity/Member.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/entity/Member.java
@@ -28,6 +28,12 @@ public class Member {
     private MemberRole role = MemberRole.SILVER;
 
     @Column
+    private Long followerCount = 0L;
+
+    @Column
+    private Long followingCount = 0L;
+
+    @Column
     private Social social;
     @Column
     private String refreshToken;

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/repository/FollowRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/repository/FollowRepository.java
@@ -1,0 +1,12 @@
+package com.bluehair.hanghaefinalproject.member.repository;
+
+import com.bluehair.hanghaefinalproject.member.entity.Follow;
+import com.bluehair.hanghaefinalproject.member.entity.FollowCompositeKey;
+import org.springframework.stereotype.Component;
+
+@Component
+public interface FollowRepository {
+    Follow save(Follow follow);
+    void deleteById(FollowCompositeKey followCompositeKey);
+    Boolean existsById(FollowCompositeKey followCompositeKey);
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/repository/JPAFollowRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/repository/JPAFollowRepository.java
@@ -1,0 +1,8 @@
+package com.bluehair.hanghaefinalproject.member.repository;
+
+import com.bluehair.hanghaefinalproject.member.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JPAFollowRepository extends JpaRepository<Follow, Long>, FollowRepository {
+
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/repository/JPAMemberRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/repository/JPAMemberRepository.java
@@ -2,7 +2,15 @@ package com.bluehair.hanghaefinalproject.member.repository;
 
 import com.bluehair.hanghaefinalproject.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface JPAMemberRepository extends JpaRepository<Member, Long>, MemberRepository  {
+    @Modifying
+    @Query("UPDATE Member SET followingCount = ?1 WHERE id = ?2")
+    void updateFollowingCount(Long followingCount, Long memberId);
 
+    @Modifying
+    @Query("UPDATE Member SET followerCount =?1 WHERE id = ?2")
+    void updateFollowerCount(Long followerCount, Long memberId);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/repository/MemberRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/repository/MemberRepository.java
@@ -10,5 +10,7 @@ public interface MemberRepository {
     Member save(Member member);
     Optional<Member> findByEmail(String email);
     Optional<Member> findByNickname(String nickname);
+    void updateFollowingCount(Long followingCount, Long memberId);
+    void updateFollowerCount(Long followerCount, Long memberId);
 
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
팔로우 기능 구현입니다.
### 1. RequestDTO 관련
팔로우 기능을 구현할 때, RequestDTO의 구현 방법은 크게 두 가지로 나눌 수 있으며, 장단점은 다음과 같습니다.
#### 1. FE에서 팔로우/언팔로우 여부를 보내주는 경우
1) 장점 : FE는 팔로우 혹은 언팔로우 하려는 유저의 닉네임만 보내면 된다.
2) 단점 : BE에서 요청을 처리할 때, 서비스 계층에서 팔로우/언팔로우 여부를 확인하고 분기처리 해야한다. 
#### 2. FE에서 팔로우/언팔로우 여부를 보내주지 않는 경우
1) 장점 : BE에서 요청을 분기처리 된 상태로 서비스 계층에 전달할 수 있다. 팔로우/언팔로우에 따라 별도의 Transaction을 사용해 처리할 수 있다. -> 팔로우/언팔로우에 따라 추가적인 비즈니스 로직을 넣기 용이하다.
2) 단점 : FE가 귀찮다.

결론적으로 2번 방법을 선택했습니다. 추후 어떤 로직을 추가적으로 구현하게 될지는 모르지만 팔로우/언팔로우 관련 서비스를 나누어 처리하는 것이 맞다고 판단했기 때문입니다!

## 작업사항
- Follow Entity 구현
- Follow CompositeKey 구현
- Member Entity 내 팔로워, 팔로잉 카운트 추가
- Follow 관련 DTO 구현
- SwaggerConfig에서 Pageable Parameter 예외처리

## 변경로직
- 없음
close #69