### PR TITLE
✨ Feat: 게시물 저장 시 Tag 추출 및 저장

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/common/service/TagExctractor.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/service/TagExctractor.java
@@ -1,0 +1,31 @@
+package com.bluehair.hanghaefinalproject.common.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class TagExctractor {
+    public List<String> extractAtTags(String contents) {
+        List<String> result = new ArrayList<>();
+        String[] splitted = contents.split(" ");
+        for (String s : splitted) {
+            if(s.charAt(0) == '@'){
+                result.add(s.substring(1));
+            }
+        }
+        return result;
+    }
+
+    public List<String> extractHashTags(String contents) {
+        List<String> result = new ArrayList<>();
+        String[] splitted = contents.split(" ");
+        for (String s : splitted) {
+            if(s.charAt(0) == '#'){
+                result.add(s.substring(1));
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/tag/entity/Tag.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/tag/entity/Tag.java
@@ -1,6 +1,7 @@
 package com.bluehair.hanghaefinalproject.tag.entity;
 
 import com.bluehair.hanghaefinalproject.post.entity.Post;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,14 @@ public class Tag {
     private String contents;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "POST_ID")
+    @JoinColumn(name = "POST_ID", nullable = false)
     private Post post;
+
+    @Builder
+    public Tag(String contents, Post post) {
+        this.contents = contents;
+        this.post = post;
+
+        post.getTagList().add(this);
+    }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/tag/mapper/TagMapStruct.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/tag/mapper/TagMapStruct.java
@@ -1,0 +1,18 @@
+package com.bluehair.hanghaefinalproject.tag.mapper;
+
+import com.bluehair.hanghaefinalproject.post.entity.Post;
+import com.bluehair.hanghaefinalproject.tag.entity.Tag;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface TagMapStruct {
+    TagMapStruct TAG_MAPPER = Mappers.getMapper(TagMapStruct.class);
+
+    default Tag stringToTag(String contents, Post post) {
+        return Tag.builder()
+                .contents(contents)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/tag/repository/JPATagRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/tag/repository/JPATagRepository.java
@@ -1,0 +1,12 @@
+package com.bluehair.hanghaefinalproject.tag.repository;
+
+import com.bluehair.hanghaefinalproject.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface JPATagRepository extends JpaRepository<Tag, Long>, TagRepository {
+    default void saveTagList(List<Tag> tagList){
+        saveAll(tagList);
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/tag/repository/TagRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/tag/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package com.bluehair.hanghaefinalproject.tag.repository;
+
+import com.bluehair.hanghaefinalproject.tag.entity.Tag;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public interface TagRepository {
+    Tag save(Tag tag);
+    void saveTagList(List<Tag> tagList);
+}


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
게시물 저장 시 Tag 추출 및 저장 기능입니다.
### 1. JpaRepository 관련
Jpa에서 기본적으로 제공하는 saveAll()을 사용하려 했는데, 저희가 Repository를 상속하는 JpaRepository로 구현하다보니 살짝 어려움이 있었습니다. 결론적으로, JpaRepository 내에서 saveAll()을 사용하는 메소드를 구현하는 것으로 마무리했습니다!
@Query를 사용한 jpql은 insert를 지원하지 않고, entitymanager(? 단어가 정확히 기억이 안납니다ㅠ)를 통해 insert 관련 로직이 구현된다고 합니다.
saveAll()은 save()를 여러번 사용하는 것보다 약 60%정도 성능 개선이 가능하다고 합니다.

### 2. `TagExtractor` 관련
`TagExtractor`는 `Common` 패키지의 `Service` 패키지에 위치해 있습니다. 혹시 `@` 관련 태그도 사용하게 될까봐 미리 구현을 해두었습니다. Tag는 저장 시, `#` 혹은 `@`이 제거된 채로 저장될 수 있도록 하였습니다. (이미  DB Table에 Tag라는 것이 명시되기 때문)

### 3. 결과
![image](https://user-images.githubusercontent.com/72681875/211148532-17113718-f23f-4afb-91a8-c0b8c870ceec.png)

![image](https://user-images.githubusercontent.com/72681875/211148519-4ec15900-acde-4fa5-bdd0-562a99b2fd54.png)


## 작업사항
- Tag Entity 빌더 및 양방향 연관관계 설정
- Tag Mapstruct 구현
- Tag 관련 Repository 구현
- Tag Extractor 구현
- Post Service 내 저장 로직 구현

close #77

## 변경로직
- 내용을 적어주세요.
