### PR TITLE
✨ Feat : 게시글 전체 조회 Profile 중복 제거

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/music/repository/MusicRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/repository/MusicRepository.java
@@ -15,6 +15,8 @@ public interface MusicRepository extends JpaRepository<Music, Long> {
     List<Music> findAllByCollaboRequest(CollaboRequest collaboRequest);
 
     List<Music> findAllByCollaboRequestId(long collaboid);
+
+    List<Music> findAllByCollaboRequest_Nickname(String nickname);
     @Transactional
     @Modifying
     @Query("DELETE from Music c where c.collaboRequest = :collaboRequest")

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/dto/serviceDto/MainPostDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/dto/serviceDto/MainPostDto.java
@@ -12,16 +12,16 @@ public class MainPostDto {
     private String title;
     private Long viewCount;
     private Long likeCount;
-    private List<String> musicFileList;
+    private String musicFile;
     private List<MainProfileDto> mainProfileList;
 
     @Builder
-    public MainPostDto(Long id, String  title, Long likeCount, Long viewCount, List<String> musicFileList, List<MainProfileDto> mainProfileList){
+    public MainPostDto(Long id, String  title, Long likeCount, Long viewCount, String musicFile, List<MainProfileDto> mainProfileList){
         this.id = id;
         this.title = title;
         this.likeCount = likeCount;
         this.viewCount = viewCount;
-        this.musicFileList = musicFileList;
+        this.musicFile = musicFile;
         this.mainProfileList = mainProfileList;
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/dto/serviceDto/MainProfileDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/dto/serviceDto/MainProfileDto.java
@@ -9,10 +9,12 @@ public class MainProfileDto {
     private List<String> musicPartList;
     private String profileImg;
 
+    private String nickname;
 
-    public MainProfileDto (List<String> musicPartList, String profileImg){
+    public MainProfileDto (List<String> musicPartList, String profileImg, String nickname){
         this.musicPartList = musicPartList;
         this.profileImg = profileImg;
+        this.nickname = nickname;
     }
 
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/mapper/PostMapStruct.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/mapper/PostMapStruct.java
@@ -14,6 +14,6 @@ import java.util.List;
 public interface PostMapStruct {
     PostMapStruct POST_MAPPER = Mappers.getMapper(PostMapStruct.class);
     Post PostDtoToPost(PostDto postDto, String nickname);
-    MainPostDto PostToMainPostDto(Long id, String title, Long likeCount, Long viewCount, List<String> musicFileList
+    MainPostDto PostToMainPostDto(Long id, String title, Long likeCount, Long viewCount, String musicFile
                                 ,List<MainProfileDto> mainProfileList);
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
게시글 마다의 콜라보 참여자 리스트가 중복되지 않도록 구현했습니다.

추가로 한 사람이 같은 MusicPart를 여러번 Collabo했을 경우에
MusicPartList 또한 중복이 제거되도록 구현하였습니다.


## 작업사항
- 게시글 전체 조회 Profile 중복 제거

close #93 
