### PR TITLE
✨ Feat: 게시글 상세 조회 시 음악 리스트 반환 API 구현 #144

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/dto/CollaboRequestListForPostDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/dto/CollaboRequestListForPostDto.java
@@ -24,21 +24,16 @@ public class CollaboRequestListForPostDto {
     @ArraySchema
     private List<String> musicPartsList;
 
-    @ArraySchema
-    private List<String> musicFileList;
-
     @Builder
     public CollaboRequestListForPostDto(Long collaboId, String nickname,
                                         String profileImg, LocalDateTime createdAt,
-                                        LocalDateTime modifiedAt, List<String> musicPartsList,
-                                        List<String> musicFileList) {
+                                        LocalDateTime modifiedAt, List<String> musicPartsList) {
         this.collaboId = collaboId;
         this.nickname = nickname;
         this.profileImg = profileImg;
         this.createdAt = LocalDateTimeConverter.timeToString(createdAt);
         this.modifiedAt = LocalDateTimeConverter.timeToString(modifiedAt);
         this.musicPartsList = musicPartsList;
-        this.musicFileList = musicFileList;
 
     }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/mapper/CollaboRequestMapStruct.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/mapper/CollaboRequestMapStruct.java
@@ -30,8 +30,7 @@ public interface CollaboRequestMapStruct {
 
     default CollaboRequestListForPostDto CollaboRequestListtoCollaboRequestListDto(CollaboRequest collaboRequest,
                                                                            String profileImg,
-                                                                           List<String> musicPartsList,
-                                                                           List<String> musicFileList){
+                                                                           List<String> musicPartsList){
         return CollaboRequestListForPostDto.builder()
                 .collaboId(collaboRequest.getId())
                 .nickname(collaboRequest.getNickname())
@@ -39,7 +38,6 @@ public interface CollaboRequestMapStruct {
                 .createdAt(collaboRequest.getCreatedAt())
                 .modifiedAt(collaboRequest.getModifiedAt())
                 .musicPartsList(musicPartsList)
-                .musicFileList(musicFileList)
                 .build();
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
@@ -73,7 +73,7 @@ public class CollaboRequestService {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaborequestid)
                 .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND));
         List<Music> musicList = musicRepository.findAllByCollaboRequest(collaboRequest);
-        List<ResponseMusicDto> musicDtoList = MUSIC_MAPPER.MusictoResponseMusicDto(musicList);
+        List<ResponseMusicDto> musicDtoList = MUSIC_MAPPER.MusictoResponseMusicDto(musicList, collaboRequest);
 
         return new ResponseCollaboRequestDto(collaboRequest, musicDtoList);
     }
@@ -89,19 +89,17 @@ public class CollaboRequestService {
         for (CollaboRequest collaboRequest : collaboRequestList) {
             if (collaboRequest.getApproval()) {
                 List<String> musicPartsList = new ArrayList<>();
-                List<String> musicFileList = new ArrayList<>();
                 List<Music> musiclist = musicRepository.findAllByCollaboRequestId(collaboRequest.getId());
 
                 for (Music music : musiclist) {
                     musicPartsList.add(music.getMusicPart());
-                    musicFileList.add(music.getMusicFile());
                 }
 
                 Member member = memberRepository.findByNickname(collaboRequest.getNickname())
                         .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND));
                 String profileImg = member.getProfileImg();
 
-                collaboRequestListForPostDto.add(COLLABOREQUEST_MAPPER.CollaboRequestListtoCollaboRequestListDto(collaboRequest, profileImg, musicPartsList, musicFileList));
+                collaboRequestListForPostDto.add(COLLABOREQUEST_MAPPER.CollaboRequestListtoCollaboRequestListDto(collaboRequest, profileImg, musicPartsList));
             }
         }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
@@ -23,6 +23,7 @@ public enum SucessCode {
     CREATE_POST(HttpStatus.OK, "게시글 작성 성공", 2000),
     UPDATE_POST(HttpStatus.OK, "게시글 수정 성공", 2000),
     MAIN_POST(HttpStatus.OK, "게시글 전체 조회 성공",2000),
+    MUSIC_POST(HttpStatus.OK, "게시글 음악 전체 조회 성공",2000),
 
     //Comment
     CREATE_COMMENT(HttpStatus.OK,"댓글 작성 성공",2000),

--- a/src/main/java/com/bluehair/hanghaefinalproject/music/dto/ResponseMusicDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/dto/ResponseMusicDto.java
@@ -1,15 +1,23 @@
 package com.bluehair.hanghaefinalproject.music.dto;
 
+import com.bluehair.hanghaefinalproject.collaboRequest.entity.CollaboRequest;
 import com.bluehair.hanghaefinalproject.music.entity.Music;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class ResponseMusicDto {
+    @Schema(description = "음원 샘플 URL", example = "http://s3-asdfkjlasdgflkajgl")
     private String musicFile;
+    @Schema(description = "음원 파트", example = "Bass")
     private String musicPart;
-
-    public ResponseMusicDto(Music music) {
+    @Schema(description = "작성자 닉네임", example = "user01")
+    private String nickname;
+    @Builder
+    public ResponseMusicDto(Music music, CollaboRequest collaboRequest) {
         this.musicFile = music.getMusicFile();
         this.musicPart = music.getMusicPart();
+        this.nickname = collaboRequest.getNickname();
     }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/music/mapper/MusicMapStruct.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/mapper/MusicMapStruct.java
@@ -1,15 +1,26 @@
 package com.bluehair.hanghaefinalproject.music.mapper;
 
+import com.bluehair.hanghaefinalproject.collaboRequest.entity.CollaboRequest;
 import com.bluehair.hanghaefinalproject.music.dto.ResponseMusicDto;
 import com.bluehair.hanghaefinalproject.music.entity.Music;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Mapper
 public interface MusicMapStruct {
     MusicMapStruct MUSIC_MAPPER = Mappers.getMapper(MusicMapStruct.class);
-    List<ResponseMusicDto> MusictoResponseMusicDto (List<Music> musicList);
+    default List<ResponseMusicDto> MusictoResponseMusicDto (List<Music> musicList, CollaboRequest collaboRequest){
+        List<ResponseMusicDto> responseMusicDtoList = new ArrayList<>();
+        for (Music music : musicList) {
+            responseMusicDtoList.add(ResponseMusicDto.builder()
+                            .music(music)
+                            .collaboRequest(collaboRequest)
+                            .build());
+        }
+        return responseMusicDtoList;
+    }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/controller/PostController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.bluehair.hanghaefinalproject.post.controller;
 
 import com.bluehair.hanghaefinalproject.common.response.success.SuccessResponse;
+import com.bluehair.hanghaefinalproject.music.dto.ResponseMusicDto;
 import com.bluehair.hanghaefinalproject.post.dto.requestDto.RequestPostDto;
 import com.bluehair.hanghaefinalproject.post.dto.requestDto.RequestUpdatePostDto;
 import com.bluehair.hanghaefinalproject.post.service.PostService;
@@ -18,11 +19,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 
-import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.CREATE_POST;
-import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.UPDATE_POST;
-import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.INFO_POST;
-import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.MAIN_POST;
+import static com.bluehair.hanghaefinalproject.common.response.success.SucessCode.*;
 
 
 @Tag(name = "Post", description = "게시글 관련 API")
@@ -84,4 +83,14 @@ public class PostController {
         return SuccessResponse.toResponseEntity(MAIN_POST,postService.mainPost(pageable));
     }
 
+    @Tag(name = "Post")
+    @Operation(summary = "상세 게시글 페이지 음악 조회", description = "상세 게시글 페이지 음악 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "2000", description = "게시글 전체 음악 조회 성공"),
+            @ApiResponse(responseCode = "4041", description = "존재하지 않는 게시글입니다.")
+    })
+    @GetMapping("/{postId}/music")
+    public ResponseEntity<SuccessResponse<List<ResponseMusicDto>>> musicPost(@PathVariable Long postId){
+        return SuccessResponse.toResponseEntity(MUSIC_POST, postService.musicPost(postId));
+    }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
@@ -10,6 +10,7 @@ import com.bluehair.hanghaefinalproject.common.exception.NotFoundException;
 import com.bluehair.hanghaefinalproject.common.service.TagExctractor;
 import com.bluehair.hanghaefinalproject.member.entity.Member;
 import com.bluehair.hanghaefinalproject.member.repository.MemberRepository;
+import com.bluehair.hanghaefinalproject.music.dto.ResponseMusicDto;
 import com.bluehair.hanghaefinalproject.music.entity.Music;
 import com.bluehair.hanghaefinalproject.music.repository.MusicRepository;
 import com.bluehair.hanghaefinalproject.post.dto.serviceDto.*;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import static com.bluehair.hanghaefinalproject.common.response.error.ErrorCode.*;
 import static com.bluehair.hanghaefinalproject.post.mapper.PostMapStruct.POST_MAPPER;
 import static com.bluehair.hanghaefinalproject.tag.mapper.TagMapStruct.TAG_MAPPER;
+import static com.bluehair.hanghaefinalproject.music.mapper.MusicMapStruct.MUSIC_MAPPER;
 
 @Service
 @RequiredArgsConstructor
@@ -147,5 +149,19 @@ public class PostService {
         post.update(postUpdateDto.getTitle(), postUpdateDto.getContents(),postUpdateDto.getLyrics(), postUpdateDto.getPostImg());
 
         postRepository.save(post);
+    }
+
+    public List<ResponseMusicDto> musicPost(Long postId){
+        List<ResponseMusicDto> responseMusicDtoList = new ArrayList<>();
+
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new NotFoundException(Domain.POST, Layer.SERVICE,POST_NOT_FOUND)
+        );
+        for (CollaboRequest collaboRequest : post.getCollaboRequestList()) {
+            if (collaboRequest.getApproval()){
+                responseMusicDtoList.addAll(MUSIC_MAPPER.MusictoResponseMusicDto(collaboRequest.getMusicList(), collaboRequest));
+            }
+        }
+        return responseMusicDtoList;
     }
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
FE(@kdh8615) 요청으로, 게시글 상세 조회 시 음악 리스트를 반환하는 API를 구현하였습니다.
추가적으로, 게시글 상세 조회 시 Collabo Request의 반환값에서 MusicFile List를 삭제해달라는 요청이 있어 함께 반영하였습니다.


## 작업사항
 - 게시글 상세 조회 시, 음악 리스트를 반환하는 API 구현
 - CollaboRequestListForPostDto 변경
 - CollaboRequestMapsturct 변경
 - MusicMapsturct 변경


## 변경로직
- `CollaboRequestForPost `반환 시, MusicFile List 반환 로직 삭제

close #144 