### PR TITLE
🐞 BugFix: postDto에서 contents에서 Tag를 추출할 시, 없을 경우 null 관련 처리가 안되는 경우 처리

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
@@ -61,16 +61,23 @@ public class PostService {
         Post post = POST_MAPPER.PostDtoToPost(postDto, nickname);
 
         postRepository.save(post);
-        // Query 최적화 필요(save < saveall < jpql)
-        if (postDto.getContents() != null || postDto.getContents() != "" || postDto.getContents() != " "){
+
+        if (postDto.getContents() != null && !Objects.equals(postDto.getContents(), "") && !Objects.equals(postDto.getContents(), " ")){
             List<String> hashtagList = tagExctractor.extractHashTags(postDto.getContents());
+            saveHashtagList(post, hashtagList);
+        }
+        return post.getId();
+    }
+
+    private void saveHashtagList(Post post, List<String> hashtagList) {
+        if (hashtagList.size() != 0){
             List<Tag> tagList = new ArrayList<>();
             for (String s : hashtagList) {
                 tagList.add(TAG_MAPPER.stringToTag(s, post));
             }
+            // Query 최적화 필요(save < saveall < jpql)
             tagRepository.saveTagList(tagList);
         }
-        return post.getId();
     }
 
     @Transactional


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
현재 FE에서 유저가 contents에 입력한 내용이 없을 시, "", " ", null 중 하나로 반환하고 있습니다.
입력한 내용이 없을 시, TagExtractor를 호출하지 않도록 수정하였으며, 
추출된 Tag가 없는 경우 역시 tagRepository.save()를 호출하지 않도록 수정하였습니다.


## 작업사항
- `createPost` 메소드 로직 변경
- `saveHashtagList` 메소드 추가(목적 : code depth 완화)


## 변경로직
- `contents`의 value가 null, "", " "이 아닐 때 tag 추출 시행
- tag 추출 결과가 있는 경우에만, `tagRepository.saveTagList(tagList);` 실행