### PR TITLE
🐞 BugFix 게시글 좋아요 비관적 락 추가

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/like/repository/PostLikeRepository.java
@@ -2,15 +2,26 @@ package com.bluehair.hanghaefinalproject.like.repository;
 
 import com.bluehair.hanghaefinalproject.like.entity.PostLike;
 import com.bluehair.hanghaefinalproject.like.entity.PostLikeCompositeKey;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
 import java.util.Optional;
 
 @Component
 public interface PostLikeRepository {
+    @Transactional
     PostLike save(PostLike postLike);
     @Transactional
     void deleteById(PostLikeCompositeKey postLikeCompositeKey);
+
+    @Transactional
     Optional<PostLike> findById(PostLikeCompositeKey postLikeCompositeKey);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Transactional
+    @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="3000")})
+    Optional<PostLike> findByPostLikedIdAndMemberId(Long postLikedId, Long memberId);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/like/service/LikeService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/like/service/LikeService.java
@@ -48,19 +48,19 @@ public class LikeService {
         PostLikeCompositeKey postLikeCompositeKey
                 = new PostLikeCompositeKey(member.getId(), postliked.getId());
         boolean likecheck;
-
-        if(postLikeRepository.findById(postLikeCompositeKey).isPresent()){
+        Optional<PostLike> postLike= postLikeRepository.findByPostLikedIdAndMemberId(postliked.getId(), member.getId());
+        if(postLike.isPresent()){
             postLikeRepository.deleteById(postLikeCompositeKey);
-            postliked.disLike();
+            postliked.unLike();
             postRepository.save(postliked);
             likecheck = false;
 
             return new PostLikeDto(likecheck, postliked.getLikeCount());
         }
 
-        postLikeRepository.save(new PostLike(postLikeCompositeKey, member,postliked));
+        postLikeRepository.save(new PostLike(postLikeCompositeKey, member, postliked));
         likecheck=true;
-        postliked.likeCount();
+        postliked.like();
         postRepository.save(postliked);
 
         Member postMember = memberRepository.findByNickname(postliked.getNickname())

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/entity/Post.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/entity/Post.java
@@ -82,11 +82,11 @@ public class Post extends Timestamped {
 
     }
 
-    public void likeCount(){
+    public void like(){
         this.likeCount++;
     }
 
-    public void disLike(){
+    public void unLike(){
         this.likeCount--;
     }
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
transaction 충돌이 일어나 좋아요 정보 변경에 에러가 발생하는 현상을 막기 위해 충돌이 일어난다는 가정하여 비관적 락을 걸었습니다.
비관적 락은 충돌 발생시 그 충돌여부를 바로 알 수 있습니다.


## 작업사항
- @Lock(LockModeType.PESSIMISTIC_WRITE) 을 추가하여 충돌을 방지하였습니다.
- @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="3000")}) 를 사용하여 3초간 타임아웃을 주었습니다. 추후 필요에 따라 변경 가능합니다.
- FE 와 상의 후, 성능 저하 또는 같은 버그 발생시 낙관적 락으로 변경해보려고 합니다.



## 변경로직
close #203 
