### PR TITLE
💎 Refactor: 알림 구독 시 멤버 정보를 nickname으로 가져옴

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/controller/NotificationController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/controller/NotificationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,7 @@ import static com.bluehair.hanghaefinalproject.common.response.success.SucessCod
 @Tag(name = "SSE", description = "SSE 관련 API")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationController {
 
     private final NotificationService notificationService;
@@ -32,10 +34,10 @@ public class NotificationController {
             @ApiResponse(responseCode = "5000", description = "SSE 연결 실패")
     })
     @Operation(summary = "SSE 연결")
-    @GetMapping(value="/api/subscribe", produces = "text/event-stream")
-    public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestHeader(value="Last-Event-ID", required = false, defaultValue = "") String lastEventId ){
+    @GetMapping(value="/api/subscribe/{nickname}", produces = "text/event-stream")
+    public SseEmitter subscribe(@PathVariable String nickname, @RequestHeader(value="Last-Event-ID", required = false, defaultValue = "") String lastEventId ){
 
-        return notificationService.subscribe(userDetails.getMember().getId(), lastEventId);
+        return notificationService.subscribe(nickname, lastEventId);
     }
 
     @Tag(name = "SSE")


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
기존에 토큰에 담겨오는 member info를 가져오려고 했는데 SSE 통신 시, 클라이언트에서 토큰 값을 보내는 게 불가능해서 nickname을 url에 보내는 것으로 변경하였습니다.


## 작업사항
- userdetail 대신 url의 nickname 값을 가져와서 member info를 확인합니다.

## 변경로직
close #215 
