### PR TITLE
💎 Refactor: Exception Convention 변경

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/controller/CollaboRequestController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/controller/CollaboRequestController.java
@@ -57,24 +57,6 @@ public class CollaboRequestController {
 
     @Tag(name = "CollaboRequest")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "2000", description = "콜라보리퀘스트 작성 성공"),
-            @ApiResponse(responseCode = "4041", description = "존재하지 않는 게시글"),
-            @ApiResponse(responseCode = "4003", description = "유효하지 않은 음원")
-    })
-    @Operation(summary = "게시물에 대한 첫 콜라보 리퀘스트 작성", description = "해당 Post에 대한 첫 콜라보 리퀘스트 작성")
-    @PostMapping("/api/post/{postid}/collabo/first")
-    public ResponseEntity<SuccessResponse<Object>> collaboRequestFirst(@PathVariable Long postid,
-                                                                  @RequestPart(value = "jsonData") RequestCollaboRequestDto requestCollaboRequestDto,
-                                                                  @Parameter(description = "WAV 및 2 Channel 오디오만 지원합니다.")
-                                                                  @RequestPart(value = "musicFile") List<MultipartFile> musicFileList,
-                                                                  @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-        Long collaboRequestId = collaboRequestService.collaboRequestFirst(postid, requestCollaboRequestDto.tocollaboRequestDetailsDto(), customUserDetails.getMember());
-        musicService.saveMusic(musicFileList, postid, requestCollaboRequestDto.getMusicPartList(), collaboRequestId);
-        return SuccessResponse.toResponseEntity(COLLABO_REQUEST_SUCCESS, collaboRequestId);
-    }
-
-    @Tag(name = "CollaboRequest")
-    @ApiResponses(value = {
             @ApiResponse(responseCode = "2000", description = "콜라보리퀘스트 상세 조회 성공"),
             @ApiResponse(responseCode = "4041", description = "존재하지 않는 게시글"),
             @ApiResponse(responseCode = "4042", description = "존재하지 않는 콜라보리퀘스트")

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
@@ -174,7 +174,7 @@ public class CollaboRequestService {
             throw new NotAuthorizedMemberException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
         if(collaboRequest.getApproval()){
-            throw new InvalidRequestException(COLLABO_REQUEST, SERVICE, COLLABO_ALREADY_APPROVED);
+            throw new InvalidRequestException(COLLABO_REQUEST, SERVICE, COLLABO_ALREADY_APPROVED, "CollaboRequest Status : " + collaboRequest.getApproval());
         }
     }
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
@@ -53,7 +53,7 @@ public class CollaboRequestService {
     @Transactional
     public Long collaboRequest(Long postId, CollaboRequestDetailsDto collaboRequestDetailsDto, Member member) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND, "Post ID : " + postId));
 
         String nickname = member.getNickname();
 
@@ -64,7 +64,7 @@ public class CollaboRequestService {
 
         //post 작성자에게 콜라보 요청 알림 - 콜라보 상세 조회로 이동
         Member postMember = memberRepository.findByNickname(post.getNickname())
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + post.getNickname()));
         Long collaboId = collaboRequest.getId();
         String content = post.getTitle()+"에 대한 콜라보 요청이 있습니다.";
         notificationService.send(postMember, member, NotificationType.COLLABO_REQUEST, content, RedirectionType.collaboRequested, collaboId, postId);
@@ -73,23 +73,9 @@ public class CollaboRequestService {
     }
 
     @Transactional
-    public Long collaboRequestFirst(Long postId, CollaboRequestDetailsDto collaboRequestDetailsDto, Member member) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND));
-
-        String nickname = member.getNickname();
-
-        CollaboRequestDto collaboRequestDto = COLLABOREQUEST_MAPPER.CollaboRequestDetailsDtotoCollaboRequestDto(collaboRequestDetailsDto, nickname);
-        CollaboRequest collaboRequest = COLLABOREQUEST_MAPPER.CollaboRequestDtotoCollaboRequest(collaboRequestDto, post);
-
-        collaboRequestRepository.save(collaboRequest);
-        return collaboRequest.getId();
-    }
-
-    @Transactional
     public ResponseCollaboRequestDto getCollaboRequest(Long collaborequestid) {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaborequestid)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND, "CollbaoRequest ID : " + collaborequestid));
         List<Music> musicList = musicRepository.findAllByCollaboRequest(collaboRequest);
         List<ResponseMusicDto> musicDtoList = MUSIC_MAPPER.MusictoResponseMusicDto(musicList, collaboRequest);
 
@@ -99,7 +85,7 @@ public class CollaboRequestService {
     @Transactional
     public List<CollaboRequestListForPostDto> getCollaboRequestList(Long postid, Member member) {
         Post post = postRepository.findById(postid)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND, "Post ID : " + postid));
 
         List<CollaboRequestListForPostDto> collaboRequestListForPostDto = new ArrayList<>();
         List<CollaboRequest> collaboRequestList = collaboRequestRepository.findAllByPost(post);
@@ -114,7 +100,7 @@ public class CollaboRequestService {
                 }
 
                 Member collabomember = memberRepository.findByNickname(collaboRequest.getNickname())
-                        .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND));
+                        .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + collaboRequest.getNickname()));
                 String profileImg = collabomember.getProfileImg();
                 Long followerCount = collabomember.getFollowerCount();
                 Boolean isFollowed = false;
@@ -137,9 +123,9 @@ public class CollaboRequestService {
     @Transactional
     public void approveCollaboRequest(Long collaborequestid, Member member) {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaborequestid)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND, "CollaboRequest ID : " + collaborequestid));
         Post post = postRepository.findById(collaboRequest.getPost().getId())
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND, "Post ID : " + collaboRequest.getPost().getId()));
         if (!post.getNickname().equals(member.getNickname())) {
             throw new NotAuthorizedMemberException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_AUTHORIZED);
         }
@@ -151,7 +137,7 @@ public class CollaboRequestService {
         //요청한 사람한테 승인 완료 알림 - 게시글 상세 조회로 이동
         Long postId = post.getId();
         Member collaboMember = memberRepository.findByNickname(collaboRequest.getNickname())
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + collaboRequest.getNickname()));
         if (!collaboMember.getNickname().equals(member.getNickname())) {
             String content = post.getTitle() + "에 대한 콜라보 요청이 승인되었습니다.";
             notificationService.send(collaboMember, member, NotificationType.COLLABO_APPROVED, content, RedirectionType.detail, postId, null);
@@ -161,7 +147,7 @@ public class CollaboRequestService {
     @Transactional
     public void deleteCollaboRequest(Long collaborequestid, Member member) {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaborequestid)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND, "CollaboRequest ID : " + collaborequestid));
 
         checkCollaboMember(member, collaboRequest);
 
@@ -173,7 +159,7 @@ public class CollaboRequestService {
                                      CollaboRequestDetailsDto collaboRequestDetailsDto,
                                      Member member) {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaborequestid)
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, COLLABO_NOT_FOUND, "CollaboRequest ID : " + collaborequestid));
 
         checkCollaboMember(member, collaboRequest);
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
@@ -127,7 +127,7 @@ public class CollaboRequestService {
         Post post = postRepository.findById(collaboRequest.getPost().getId())
                 .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, POST_NOT_FOUND, "Post ID : " + collaboRequest.getPost().getId()));
         if (!post.getNickname().equals(member.getNickname())) {
-            throw new NotAuthorizedMemberException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_AUTHORIZED);
+            throw new NotAuthorizedMemberException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
 
         Boolean approval = true;
@@ -171,7 +171,7 @@ public class CollaboRequestService {
     private static void checkCollaboMember(Member member, CollaboRequest collaboRequest) {
         String nickname = collaboRequest.getNickname();
         if(!nickname.equals(member.getNickname())){
-            throw new NotAuthorizedMemberException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_AUTHORIZED);
+            throw new NotAuthorizedMemberException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
         if(collaboRequest.getApproval()){
             throw new InvalidRequestException(COLLABO_REQUEST, SERVICE, COLLABO_ALREADY_APPROVED);

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
@@ -64,7 +64,7 @@ public class CollaboRequestService {
 
         //post 작성자에게 콜라보 요청 알림 - 콜라보 상세 조회로 이동
         Member postMember = memberRepository.findByNickname(post.getNickname())
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + post.getNickname()));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND,"Nickname : " + post.getNickname()));
         Long collaboId = collaboRequest.getId();
         String content = post.getTitle()+"에 대한 콜라보 요청이 있습니다.";
         notificationService.send(postMember, member, NotificationType.COLLABO_REQUEST, content, RedirectionType.collaboRequested, collaboId, postId);

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/service/CollaboRequestService.java
@@ -64,7 +64,7 @@ public class CollaboRequestService {
 
         //post 작성자에게 콜라보 요청 알림 - 콜라보 상세 조회로 이동
         Member postMember = memberRepository.findByNickname(post.getNickname())
-                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COLLABO_REQUEST, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + post.getNickname()));
 
         if (!collaboRequest.getNickname().equals(member.getNickname())){
             Long collaboId = collaboRequest.getId();

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/service/CommentService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/service/CommentService.java
@@ -48,16 +48,16 @@ public class CommentService {
     public void createComment(Long postId,Long parentId, CommentDto commentDto, String nickname) {
 
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT, Layer.SERVICE,POST_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT, Layer.SERVICE,POST_NOT_FOUND, "Post ID : " + postId)
         );
         if (parentId != null){
             commentRepository.findById(parentId).orElseThrow(
-                    () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND)
+                    () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND, "Parent Comment ID : " + parentId)
             );
         }
 
         Member member = memberRepository.findByNickname(nickname)
-                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + nickname));
         Long likeCount = 0L;
         Comment comment = new Comment(parentId, nickname, member.getProfileImg(),commentDto.getContents(),likeCount, post);
 
@@ -65,7 +65,7 @@ public class CommentService {
 
         //post 작성자에게 댓글 알림 - 댓글 조회로 이동
         Member postMember = memberRepository.findByNickname(post.getNickname())
-                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + nickname));
 
         if(!postMember.getNickname().equals(member.getNickname())) {
             String content = post.getTitle() + "에 " + nickname + "님이 댓글을 남겼습니다.";
@@ -76,10 +76,10 @@ public class CommentService {
     public void updateComment(Long commentId, CommentDto commentDto, String nickname) {
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND, "Comment ID : " + commentId)
         );
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
 
         if (!comment.getNickname().equals(member.getNickname())){
@@ -94,10 +94,10 @@ public class CommentService {
     @Transactional
     public void deleteComment(Long commentId, String nickname) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND, "Comment ID : " + commentId)
         );
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
         if (!comment.getNickname().equals(member.getNickname())){
             throw new NotAuthorizedMemberException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_AUTHORIZED);
@@ -121,7 +121,7 @@ public class CommentService {
                 }
             }
             Comment comments = commentRepository.findById(comment.getId()).orElseThrow(
-                    () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND)
+                    () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND, "Comment ID : " + comment.getId())
             );
 
             List<Comment> ParentsCommentList = commentRepository.findByParentsId(comments.getId());

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/service/CommentService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/service/CommentService.java
@@ -83,7 +83,7 @@ public class CommentService {
         );
 
         if (!comment.getNickname().equals(member.getNickname())){
-             throw new NotAuthorizedMemberException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_AUTHORIZED);
+             throw new NotAuthorizedMemberException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
 
         comment.update(commentDto);
@@ -100,7 +100,7 @@ public class CommentService {
                 () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
         if (!comment.getNickname().equals(member.getNickname())){
-            throw new NotAuthorizedMemberException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_AUTHORIZED);
+            throw new NotAuthorizedMemberException(Domain.COMMENT,Layer.SERVICE,MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
         deleteCommentLike(commentId);
         commentRepository.deleteById(commentId);

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/DuplicationException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/DuplicationException.java
@@ -10,4 +10,5 @@ public class DuplicationException extends IllegalArgumentException{
     private Domain domain;
     private Layer layer;
     private ErrorCode errorCode;
+    private Object causeVariable;
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/FormatException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/FormatException.java
@@ -11,4 +11,5 @@ public class FormatException extends IllegalArgumentException {
     private Domain domain;
     private Layer layer;
     private ErrorCode errorCode;
+    private Object causeVariable;
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
@@ -56,6 +56,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @Transactional
     public ResponseEntity<ErrorResponse> handleInvalidAudioFileException(InvalidAudioFileException e) {
         log.error("InvalidAudioFileException throwed at " + e.getDomain() + "_"+ e.getLayer() + " : " + e.getErrorCode());
+        log.error("Cause : " + e.getCauseVariable());
+
         if(e.getCollaboRequest()!=null){
             collaboRequestRepository.delete(e.getCollaboRequest());
         }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
@@ -48,6 +48,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleInvalidRequestException(InvalidRequestException e) {
         log.error("InvalidRequestException throwed at " + e.getDomain() + "_"+ e.getLayer() + " : " + e.getErrorCode());
+        log.error("Cause : " + e.getCauseVariable());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
         log.error("NotFoundException throwed at " + e.getDomain() + "_"+ e.getLayer() + " : " + e.getErrorCode());
+        log.error("Cause : " + e.getCauseVariable());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 
@@ -32,12 +33,14 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleFormatException(FormatException e) {
         log.error("FormatException throwed at " + e.getDomain() + "_"+ e.getLayer() + " : " + e.getErrorCode());
+        log.error("Cause : " + e.getCauseVariable());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleDuplicationException(DuplicationException e) {
         log.error("DuplicationException throwed at " + e.getDomain() + "_"+ e.getLayer() + " : " + e.getErrorCode());
+        log.error("Cause : " + e.getCauseVariable());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/GlobalExceptionHandler.java
@@ -27,6 +27,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> handleNotAuthorizedMemberException(NotAuthorizedMemberException e) {
         log.error("NotAuthorizedMemberException throwed at " + e.getDomain() + "_"+ e.getLayer() + " : " + e.getErrorCode());
+        log.error("Cause : " + e.getCauseVariable());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/InvalidAudioFileException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/InvalidAudioFileException.java
@@ -14,4 +14,5 @@ public class InvalidAudioFileException extends IllegalArgumentException {
     private ErrorCode errorCode;
     private CollaboRequest collaboRequest;
     private Post post;
+    private Object causeVariable;
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/InvalidRequestException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/InvalidRequestException.java
@@ -10,4 +10,5 @@ public class InvalidRequestException extends IllegalArgumentException {
     private Domain domain;
     private Layer layer;
     private ErrorCode errorCode;
+    private Object causeVariable;
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/NotAuthorizedMemberException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/NotAuthorizedMemberException.java
@@ -10,4 +10,5 @@ public class NotAuthorizedMemberException extends SecurityException{
     private Domain domain;
     private Layer layer;
     private ErrorCode errorCode;
+    private Object causeVariable;
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/exception/NotFoundException.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/exception/NotFoundException.java
@@ -10,4 +10,5 @@ public class NotFoundException extends IllegalArgumentException{
     private Domain domain;
     private Layer layer;
     private ErrorCode errorCode;
+    private Object causeVariable;
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/service/MultipartFileConverter.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/service/MultipartFileConverter.java
@@ -18,7 +18,6 @@ import static com.bluehair.hanghaefinalproject.common.response.error.ErrorCode.I
 public class MultipartFileConverter {
     public static final String tmpPath = System.getProperty("user.dir") + File.separator + "temp";
 
-    // 변환이 정상적으로 안되었던 이유 노션에 정리
     static public void generateTempPath() {
         File dir = new File(tmpPath);
         if(!dir.exists()) {
@@ -34,11 +33,10 @@ public class MultipartFileConverter {
     static public File convertMFileToFile(MultipartFile mFile) throws IOException {
         File file = File.createTempFile("temp_", mFile.getOriginalFilename()
                 , new File(tmpPath));
-        System.out.println("Original Filename:" + mFile.getOriginalFilename());
         try{
             mFile.transferTo(file);
         } catch (IOException e) {
-            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE);
+            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, mFile.getOriginalFilename());
         }
         return file;
     }
@@ -47,7 +45,7 @@ public class MultipartFileConverter {
         try (FileInputStream is = new FileInputStream(file)){
             IOUtils.copy(is, fileItem.getOutputStream());
         } catch (IOException ex) {
-            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE);
+            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, file.getName());
         }
         MultipartFile mFile = new CommonsMultipartFile(fileItem);
         fileItem.delete();

--- a/src/main/java/com/bluehair/hanghaefinalproject/like/service/LikeService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/like/service/LikeService.java
@@ -43,7 +43,7 @@ public class LikeService {
 
     public PostLikeDto postLike(Long postId, Member member){
         Post postliked = postRepository.findById(postId)
-                .orElseThrow(()-> new NotFoundException(LIKE, SERVICE, POST_NOT_FOUND)
+                .orElseThrow(()-> new NotFoundException(LIKE, SERVICE, POST_NOT_FOUND, "Post ID : " + postId)
                 );
         PostLikeCompositeKey postLikeCompositeKey
                 = new PostLikeCompositeKey(member.getId(), postliked.getId());
@@ -65,7 +65,7 @@ public class LikeService {
 
 
         Member postMember = memberRepository.findByNickname(postliked.getNickname())
-                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + postliked.getNickname()));
         if(!postMember.getNickname().equals(member.getNickname())) {
             String content = postliked.getTitle() + "을(를) " + member.getNickname() + "님이 좋아합니다.";
             notificationService.send(postMember, member, NotificationType.POST_LIKED, content, RedirectionType.detail, postId, null);
@@ -80,10 +80,10 @@ public class LikeService {
         boolean isLiked = false;
 
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT, Layer.SERVICE,MEMBER_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT, Layer.SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
         Comment comment = commentRepository.findById(commentId).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT,Layer.SERVICE,COMMENT_NOT_FOUND, "Comment ID : " + commentId)
         );
 
         CommentLikeCompositeKey commentLikeCompositeKey = new CommentLikeCompositeKey(commentId, member.getId());
@@ -101,7 +101,7 @@ public class LikeService {
         isLiked = true;
 
         Member commentMember = memberRepository.findByNickname(comment.getNickname())
-                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(COMMENT, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + comment.getNickname()));
         if(!commentMember.getNickname().equals(member.getNickname())) {
             Long postId = comment.getPost().getId();
             String content = commentMember.getNickname() + "님의 댓글을 " + nickname + "님이 좋아합니다.";

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
@@ -96,7 +96,7 @@ public class MemberService {
                 .orElseThrow(()->new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND, "Email : " + loginDto.getEmail()));
 
         if(!passwordEncoder.matches(loginDto.getPassword(), member.getPassword())){
-            throw new NotAuthorizedMemberException(MEMBER, SERVICE, PASSWORD_INCORRECT);
+            throw new NotAuthorizedMemberException(MEMBER, SERVICE, PASSWORD_INCORRECT, loginDto.getEmail());
         }
 
         setNewTokens(response, member);

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
@@ -151,7 +151,7 @@ public class MemberService {
                 = new FollowCompositeKey(userDetails.getMember().getId(), myFollowingMember.getId());
 
         if (followRepository.existsById(followCompositeKey)){
-            throw new InvalidRequestException(MEMBER, SERVICE, ALREADY_FOLLWED);
+            throw new InvalidRequestException(MEMBER, SERVICE, ALREADY_FOLLWED, myFollowingMember.getNickname());
         }
 
         Follow follow = new Follow(followCompositeKey, userDetails.getMember(), myFollowingMember);
@@ -170,7 +170,7 @@ public class MemberService {
                 = new FollowCompositeKey(userDetails.getMember().getId(), myFollowingMember.getId());
 
         if (!followRepository.existsById(followCompositeKey)){
-            throw new InvalidRequestException(MEMBER, SERVICE, ALREADY_UNFOLLWED);
+            throw new InvalidRequestException(MEMBER, SERVICE, ALREADY_UNFOLLWED, myFollowingMember.getNickname());
         }
 
         followRepository.deleteById(followCompositeKey);

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
@@ -40,18 +40,18 @@ public class MemberService {
     public void signUp(SignUpDto signUpDto) {
         memberRepository.findByEmail(signUpDto.getEmail())
                 .ifPresent(m->{
-                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_EMAIL);
+                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_EMAIL, signUpDto.getEmail());
                 });
         memberRepository.findByNickname(signUpDto.getNickname())
                 .ifPresent(m-> {
-                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_NICKNAME);
+                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_NICKNAME, signUpDto.getNickname());
                 });
 
         if(!Validator.isValidEmail(signUpDto.getEmail())){
-            throw new FormatException(MEMBER, SERVICE, INVALID_EMAIL);
+            throw new FormatException(MEMBER, SERVICE, INVALID_EMAIL, signUpDto.getEmail());
         }
         if(!Validator.isValidPassword(signUpDto.getPassword())){
-            throw new FormatException(MEMBER, SERVICE, INVALID_PASSWORD);
+            throw new FormatException(MEMBER, SERVICE, INVALID_PASSWORD, signUpDto.getPassword());
         }
 
         signUpDto.encryptPassword(passwordEncoder.encode(signUpDto.getPassword()));
@@ -67,18 +67,18 @@ public class MemberService {
     @Transactional(readOnly = true)
     public void validateEmail(ValidateEmailDto validateEmailDto) {
         if(!Validator.isValidEmail(validateEmailDto.getEmail())){
-            throw new FormatException(MEMBER, SERVICE, INVALID_EMAIL);
+            throw new FormatException(MEMBER, SERVICE, INVALID_EMAIL, validateEmailDto.getEmail());
         }
         memberRepository.findByEmail(validateEmailDto.getEmail())
                 .ifPresent(m->{
-                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_EMAIL);
+                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_EMAIL, validateEmailDto.getEmail());
                 });
     }
     @Transactional(readOnly = true)
     public void validateNickname(ValidateNicknameDto validateNicknameDto){
         memberRepository.findByNickname(validateNicknameDto.getNickname())
                 .ifPresent(m->{
-                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_NICKNAME);
+                    throw new DuplicationException(MEMBER, SERVICE, DUPLICATED_NICKNAME, validateNicknameDto.getNickname());
                 });
     }
 
@@ -93,7 +93,7 @@ public class MemberService {
     @Transactional
     public void login(LoginDto loginDto, HttpServletResponse response) {
         Member member = memberRepository.findByEmail(loginDto.getEmail())
-                .orElseThrow(()->new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(()->new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND, "Email : " + loginDto.getEmail()));
 
         if(!passwordEncoder.matches(loginDto.getPassword(), member.getPassword())){
             throw new NotAuthorizedMemberException(MEMBER, SERVICE, PASSWORD_INCORRECT);
@@ -111,7 +111,7 @@ public class MemberService {
         jwtUtil.validateToken(refreshToken, false);
 
         Member member = memberRepository.findByEmail(claims.getSubject())
-                .orElseThrow(()->new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(()->new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND, "Email : " + claims.getSubject()));
 
         if(!member.getRefreshToken().substring(7).equals(refreshToken)){
             throw new CustomJwtException(INVALID_REFRESHTOKEN);
@@ -145,7 +145,7 @@ public class MemberService {
     @Transactional
     public void doFollow(CustomUserDetails userDetails, FollowDto followDto) {
         Member myFollowingMember = memberRepository.findByNickname(followDto.getMyFollowingMemberNickname())
-                .orElseThrow(()-> new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(()-> new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + followDto.getMyFollowingMemberNickname()));
 
         FollowCompositeKey followCompositeKey
                 = new FollowCompositeKey(userDetails.getMember().getId(), myFollowingMember.getId());
@@ -164,7 +164,7 @@ public class MemberService {
     @Transactional
     public void doUnfollow(CustomUserDetails userDetails, FollowDto followDto) {
         Member myFollowingMember = memberRepository.findByNickname(followDto.getMyFollowingMemberNickname())
-                .orElseThrow(()-> new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND));
+                .orElseThrow(()-> new NotFoundException(MEMBER, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + followDto.getMyFollowingMemberNickname()));
 
         FollowCompositeKey followCompositeKey
                 = new FollowCompositeKey(userDetails.getMember().getId(), myFollowingMember.getId());

--- a/src/main/java/com/bluehair/hanghaefinalproject/music/service/AudioSample.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/service/AudioSample.java
@@ -32,12 +32,11 @@ public class AudioSample {
         AudioInputStream audioInputStream = AudioSystem.getAudioInputStream(file);
         format = audioInputStream.getFormat();
 
-        log.warn("filename: " + file.getName());
-        log.warn("Channels: " + format.getChannels());
-        log.warn("bitDepth: " + format.getSampleSizeInBits());
-
         if(!Validator.isValidAudioFormat(format)) {
-            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE);
+            log.warn("filename: " + file.getName());
+            log.warn("Channels: " + format.getChannels());
+            log.warn("bitDepth: " + format.getSampleSizeInBits());
+            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, "Check Above");
         }
 
         // Frame의 크기(Frame을 표현할 수 있는 범위) - byte
@@ -53,7 +52,7 @@ public class AudioSample {
 
         // AudioBytes에 오디오 인풋 저장. numbytes와 다를 경우 파일이 커서 못읽는 경우, 잘라내야함
         if(numBytes != audioInputStream.read(audioBytes)) {
-            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE);
+            throw new InvalidRequestException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, numBytes + " / " + audioInputStream.read(audioBytes));
         }
 
         convertToFloat(audioBytes, format);

--- a/src/main/java/com/bluehair/hanghaefinalproject/music/service/MusicService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/service/MusicService.java
@@ -62,7 +62,7 @@ public class MusicService {
             saveMusicListAtS3(multipartFileList, musicPartList, collaboRequest, post);
         }
         catch(UnsupportedAudioFileException | IOException | InvalidRequestException e) {
-            throw new InvalidAudioFileException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, collaboRequest, null);
+            throw new InvalidAudioFileException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, collaboRequest, null, musicPartList.toString());
         }
     }
 
@@ -174,7 +174,7 @@ public class MusicService {
             saveMusicListAtS3(multipartFileList, musicPartList, collaboRequest, post);
         }
         catch(UnsupportedAudioFileException | IOException | InvalidRequestException e) {
-            throw new InvalidAudioFileException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, null, null);
+            throw new InvalidAudioFileException(MUSIC, SERVICE, INVALID_SOUNDSAMPLE, null, null, musicPartList.toString());
         }
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/music/service/MusicService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/music/service/MusicService.java
@@ -54,9 +54,9 @@ public class MusicService {
                           List<String> musicPartList,
                           Long collaboRequestId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(()-> new NotFoundException(MUSIC, SERVICE, POST_NOT_FOUND));
+                .orElseThrow(()-> new NotFoundException(MUSIC, SERVICE, POST_NOT_FOUND, "Post ID : " + postId));
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaboRequestId)
-                .orElseThrow(()-> new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(()-> new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND, "CollaboReqeust Id : " + collaboRequestId));
 
         try {
             saveMusicListAtS3(multipartFileList, musicPartList, collaboRequest, post);
@@ -107,7 +107,7 @@ public class MusicService {
     @Transactional
     public void mixMusic(Long collaboRequestId) throws IOException, UnsupportedAudioFileException {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaboRequestId)
-                .orElseThrow(()->new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(()->new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND, "CollaboRequest ID : " + collaboRequestId));
         Post post = collaboRequest.getPost();
 
         List<File> fileList = new ArrayList<>();
@@ -149,7 +149,7 @@ public class MusicService {
     @Transactional
     public void deleteMusicList(Long collaboRequestId) {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaboRequestId)
-                .orElseThrow(() -> new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND, "CollaboRequest ID : " + collaboRequestId));
 
         for (Music music : collaboRequest.getMusicList()) {
             deleteS3(music.getMusicFile());
@@ -166,7 +166,7 @@ public class MusicService {
     @Transactional
     public void updateMusic(Long collaboRequestId, List<MultipartFile> multipartFileList, List<String> musicPartList) {
         CollaboRequest collaboRequest = collaboRequestRepository.findById(collaboRequestId)
-                .orElseThrow(()-> new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND));
+                .orElseThrow(()-> new NotFoundException(MUSIC, SERVICE, COLLABO_NOT_FOUND, "CollaboRequest ID : " + collaboRequestId));
 
         Post post = collaboRequest.getPost();
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
@@ -253,7 +253,7 @@ public class PostService {
                 () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
         if (!post.getNickname().equals(member.getNickname())){
-            throw new NotAuthorizedMemberException(POST, SERVICE,MEMBER_NOT_AUTHORIZED);
+            throw new NotAuthorizedMemberException(POST, SERVICE,MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
         tagRepository.deleteAllByPost(post);
 
@@ -294,7 +294,7 @@ public class PostService {
         );
 
         if (!post.getNickname().equals(member.getNickname())){
-            throw new NotAuthorizedMemberException(POST, SERVICE,MEMBER_NOT_AUTHORIZED);
+            throw new NotAuthorizedMemberException(POST, SERVICE,MEMBER_NOT_AUTHORIZED, member.getNickname());
         }
 
         // 해당 게시글 콜라보 리스트 조회

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostService.java
@@ -22,7 +22,6 @@ import com.bluehair.hanghaefinalproject.post.dto.serviceDto.*;
 import com.bluehair.hanghaefinalproject.post.entity.Post;
 import com.bluehair.hanghaefinalproject.post.repository.PostRepository;
 
-import com.bluehair.hanghaefinalproject.sse.repository.NotificationRepository;
 import com.bluehair.hanghaefinalproject.tag.entity.Tag;
 import com.bluehair.hanghaefinalproject.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
@@ -90,7 +89,7 @@ public class PostService {
     @Transactional
     public InfoPostDto infoPost(Long postid, Member member) {
         Post post = postRepository.findById(postid).orElseThrow(
-                () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND)
+                () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND, "Post ID : " + postid)
         );
 
         post.viewCount();
@@ -101,7 +100,7 @@ public class PostService {
 
         if(member!=null){
         Member postMember = memberRepository.findByNickname(post.getNickname()).orElseThrow(
-                () -> new NotFoundException(POST, SERVICE, MEMBER_NOT_FOUND)
+                () -> new NotFoundException(POST, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + post.getNickname())
         );
 
         PostLikeCompositeKey postLikeCompositeKey
@@ -117,7 +116,7 @@ public class PostService {
         List<MainPostDto> mainPostDtoList = new ArrayList<>();
 
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
 
         List<Post> postList = postRepository.findByNickname(pageable,nickname);
@@ -248,10 +247,10 @@ public class PostService {
     public void updatePost(Long postId, PostUpdateDto postUpdateDto, String nickname) {
 
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND)
+                () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND, "Post ID : " + postId)
         );
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
         if (!post.getNickname().equals(member.getNickname())){
             throw new NotAuthorizedMemberException(POST, SERVICE,MEMBER_NOT_AUTHORIZED);
@@ -272,7 +271,7 @@ public class PostService {
         List<ResponseMusicDto> responseMusicDtoList = new ArrayList<>();
 
         Post post = postRepository.findById(postId).orElseThrow(
-                () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND)
+                () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND, "Post ID : " + postId)
         );
         for (CollaboRequest collaboRequest : post.getCollaboRequestList()) {
             if (collaboRequest.getApproval()){
@@ -287,11 +286,11 @@ public class PostService {
 
         // 게시글 검색
         Post post = postRepository.findById(postId).orElseThrow(
-            () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND)
+            () -> new NotFoundException(POST, SERVICE,POST_NOT_FOUND, "Post ID : " + postId)
         );
 
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND)
+                () -> new NotFoundException(Domain.COMMENT, SERVICE,MEMBER_NOT_FOUND, "Nickname : " + nickname)
         );
 
         if (!post.getNickname().equals(member.getNickname())){

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
@@ -81,7 +81,7 @@ public class NotificationService {
                     .data(data));
         } catch (IOException exception) {
             emitterRepository.deleteById(emitterId);
-            throw new InvalidRequestException(SSE, SERVICE, UNHANDLED_SERVER_ERROR);
+            throw new InvalidRequestException(SSE, SERVICE, UNHANDLED_SERVER_ERROR, "Emitter ID : " + emitterId);
         }
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
@@ -41,8 +41,7 @@ public class NotificationService {
 
     public SseEmitter subscribe(String nickname, String lastEventId) {
         Member member = memberRepository.findByNickname(nickname).orElseThrow(
-                () -> new NotFoundException(SSE, SERVICE, MEMBER_NOT_FOUND)
-        );
+                () -> new NotFoundException(SSE, SERVICE, MEMBER_NOT_FOUND, "Nickname : " + nickname));
         Long memberId = member.getId();
         String emitterId = memberId + "_" + System.currentTimeMillis();
         SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
@@ -98,7 +97,7 @@ public class NotificationService {
 
     public void readNotification(Long notificationid, Member member) {
         Notification notification = notificationRepository.findById(notificationid)
-                .orElseThrow(()-> new NotFoundException(SSE, SERVICE, NOTIFICATION_NOT_FOUND));
+                .orElseThrow(()-> new NotFoundException(SSE, SERVICE, NOTIFICATION_NOT_FOUND, "Notification ID : " + notificationid));
         if(member.getId().equals(notification.getReceiver().getId())) {
             notification.read();
         }

--- a/src/test/java/com/bluehair/hanghaefinalproject/member/service/MemberServiceTest.java
+++ b/src/test/java/com/bluehair/hanghaefinalproject/member/service/MemberServiceTest.java
@@ -1,0 +1,115 @@
+package com.bluehair.hanghaefinalproject.member.service;
+
+import com.bluehair.hanghaefinalproject.collaboRequest.repository.CollaboRequestRepository;
+import com.bluehair.hanghaefinalproject.common.exception.DuplicationException;
+import com.bluehair.hanghaefinalproject.common.exception.FormatException;
+import com.bluehair.hanghaefinalproject.common.exception.GlobalExceptionHandler;
+import com.bluehair.hanghaefinalproject.member.dto.serviceDto.ValidateEmailDto;
+import com.bluehair.hanghaefinalproject.member.entity.Member;
+import com.bluehair.hanghaefinalproject.member.repository.MemberRepository;
+import com.bluehair.hanghaefinalproject.post.repository.PostRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.StopWatch;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CollaboRequestRepository collaboRequestRepository;
+
+    @Mock
+    private PostRepository postRepository;
+    StopWatch stopwatch;
+    GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler(collaboRequestRepository, postRepository);
+
+    @BeforeEach
+    void setData() {
+        stopwatch = new StopWatch("API Controller Test");
+        stopwatch.start();
+    }
+
+    @AfterEach
+    void stop() {
+        stopwatch.stop();
+        System.out.println("===================================================");
+        System.out.println("개별 테스트 성능 측정 결과");
+        System.out.println("===================================================");
+        System.out.println("Time Seconds = "+stopwatch.getTotalTimeSeconds()+"s");
+        System.out.println("Time Millis = "+stopwatch.getTotalTimeMillis()+"ms");
+        System.out.println("Time Nanos = "+stopwatch.getTotalTimeNanos()+"ns");
+        System.out.println(stopwatch.prettyPrint());
+        System.out.println("===================================================");
+    }
+
+    @Test
+    @DisplayName("Email 검증 (1) 이메일 형식 미준수")
+    void validateEmail_WRONG_FORMAT() {
+        ValidateEmailDto validateEmailDto = ValidateEmailDto.builder()
+                .email("com")
+                .build();
+        Throwable exception = assertThrows(RuntimeException.class, () -> {
+            memberService.validateEmail(validateEmailDto);
+        });
+        globalExceptionHandler.handleFormatException((FormatException) exception);
+    }
+
+    @Test
+    @DisplayName("Email 검증 (2) 이메일 중복")
+    void validateEmail_DUPLICATED_EMAIL() {
+        ValidateEmailDto validateEmailDto = ValidateEmailDto.builder()
+                .email("asdf@asdf.com")
+                .build();
+        Member member = Member.builder().build();
+        when(memberRepository.findByEmail(validateEmailDto.getEmail())).thenReturn(Optional.ofNullable(member));
+
+        Throwable exception = assertThrows(RuntimeException.class, () -> {
+            memberService.validateEmail(validateEmailDto);
+        });
+        globalExceptionHandler.handleDuplicationException((DuplicationException) exception);
+    }
+
+    @Test
+    void validateNickname() {
+    }
+
+    @Test
+    void signUp() {
+    }
+
+    @Test
+    void login() {
+    }
+
+    @Test
+    void tokenReissuance() {
+    }
+
+    @Test
+    void memberInfo() {
+    }
+
+    @Test
+    void doFollow() {
+    }
+
+    @Test
+    void doUnfollow() {
+    }
+}


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Exception Convention 변경 작업입니다. 지난 멘토링 간, 멘토님께서 저희 Exception 처리 방식에 두 가지 추가할 사항을 말씀해주셨었습니다.

1. Custom Exception 발생 시 StackTrace
StackTrace는 분명 어떤 지점에서 Exception이 발생했는지 확인하기 위해 상당히 좋은 기능입니다. 하지만 StackTrace의 사용 시, 모든 Exception과 관련된 객체들을 명시해주기 때문에 오히려 보기 힘들 수 있다고 판단했습니다. 또한 이미 Exception마다 Domain - Layer - ErrorCode 순으로 Log를 출력해주고 있기 때문에, StackTrace의 적용은 보류하였습니다.

2. Custom Exception 발생 시 발생 요인(변수)
멘토링 간, 멘토님께서 Exception에 어떤 변수에 의해서 해당 오류가 발생하였는지 명시해주는 것이 좋을 것 같다고 말씀하셨었습니다. 상당히 좋은 의견이라고 생각되며, 각 Exception에 Object 필드를 추가하고, Obect Field에 오류의 원인이 될 수 있는 변수를 담을 수 있도록 조정하였습니다.


## 작업사항
- Exception Class에 `causeVariable` Field 추가
- Service에서 throw된 모든 Exception에 causeVariable 반영


## 변경로직
- 없음

close #224 #102 