### PR TITLE
✨ Feat EventListener 적용하여 NotificationService 의존성 제거

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/dto/RequestNotificationDto.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/dto/RequestNotificationDto.java
@@ -1,0 +1,32 @@
+package com.bluehair.hanghaefinalproject.sse.dto;
+
+import com.bluehair.hanghaefinalproject.member.entity.Member;
+import com.bluehair.hanghaefinalproject.sse.entity.NotificationType;
+import com.bluehair.hanghaefinalproject.sse.entity.RedirectionType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@Setter
+public class RequestNotificationDto {
+    private Member receiver;
+    private Member sender;
+    NotificationType notificationType;
+    private String content;
+    private RedirectionType type;
+    private Long typeId;
+    private Long postId;
+
+    public RequestNotificationDto(Member receiver, Member sender, NotificationType notificationType,
+                                  String content, RedirectionType type, Long typeId, Long postId) {
+        this.receiver = receiver;
+        this.sender = sender;
+        this.notificationType = notificationType;
+        this.content = content;
+        this.type = type;
+        this.typeId = typeId;
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/listener/NotificationListener.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/listener/NotificationListener.java
@@ -23,7 +23,7 @@ public class NotificationListener {
     public void handleNotification(RequestNotificationDto requestNotificationDto){
         notificationService.send(requestNotificationDto.getReceiver(), requestNotificationDto.getSender(),requestNotificationDto.getNotificationType(),
                 requestNotificationDto.getContent(), requestNotificationDto.getType(), requestNotificationDto.getTypeId(), requestNotificationDto.getPostId());
-        log.info("EventListener has been operated. Sender Id: " + requestNotificationDto.getSender() + "NotificationType: " +requestNotificationDto.getNotificationType());
+        log.info("EventListener has been operated. Sender Id: " + requestNotificationDto.getSender().getId() + "NotificationType: " +requestNotificationDto.getNotificationType());
     }
 
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/listener/NotificationListener.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/listener/NotificationListener.java
@@ -1,0 +1,29 @@
+package com.bluehair.hanghaefinalproject.sse.listener;
+
+import com.bluehair.hanghaefinalproject.sse.dto.RequestNotificationDto;
+import com.bluehair.hanghaefinalproject.sse.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationListener {
+
+    private final NotificationService notificationService;
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Async
+    public void handleNotification(RequestNotificationDto requestNotificationDto){
+        notificationService.send(requestNotificationDto.getReceiver(), requestNotificationDto.getSender(),requestNotificationDto.getNotificationType(),
+                requestNotificationDto.getContent(), requestNotificationDto.getType(), requestNotificationDto.getTypeId(), requestNotificationDto.getPostId());
+        log.info("EventListener has been operated. Sender Id: " + requestNotificationDto.getSender() + "NotificationType: " +requestNotificationDto.getNotificationType());
+    }
+
+}

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
@@ -43,7 +43,7 @@ public class NotificationService {
         SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
 
         emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
-        emitter.onTimeout(() -> {emitterRepository.deleteById(emitterId);emitter.complete();}); //안되면 범준님 책임
+        emitter.onTimeout(() -> {emitterRepository.deleteById(emitterId);emitter.complete();});
 
         sendToClient(emitter, emitterId, "EventStream Created. [memberId=" + memberId + "]");
 


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [ ] 커밋 제목 규칙
- [ ] 커밋 메시지 작성 가이드라인
- [ ] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
기존에 NotificationService와 알림 서비스를 사용하는 서비스간의 강한 결합도와 의존성을 낮추기 위해 EventListener를 사용하였습니다. 


## 작업사항
- NotificationListener 생성
- RequestNotificationDto 생성 (EventListener는 하나의 Parameter를 가집니다.)
- 각 도메인별 알림 서비스 관련 메서드 수정


## 변경로직
- notify 메서드 실행시, EventListener가 notificationService를 실행합니다.

close #231
