### PR TITLE
🐞 BugFix: 계정 설정 시, AccessToken 만료 Status Code 전송

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
@@ -17,7 +17,7 @@ public enum SucessCode {
     UNFOLLOW_MEMBER(HttpStatus.OK, "언팔로우 성공", 2000),
     MEMBER_INFO(HttpStatus.OK, "사용자 정보 반환 성공", 2000),
     TOKEN_REISSUANCE(HttpStatus.OK, "토큰 재발행 성공", 2001),
-    MEMBER_UPDATE_SETTING(HttpStatus.OK, "계정 설정 업데이트 성공", 2000),
+    MEMBER_UPDATE_SETTING(HttpStatus.OK, "계정 설정 업데이트 성공", 4015),
     MEMBER_GET_SETTING(HttpStatus.OK, "계정 설정 불러오기 성공", 2000),
     MEMBER_GET_MYPAGE(HttpStatus.OK, "마이페이지 유저 정보 불러오기 성공", 2000),
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/common/response/success/SucessCode.java
@@ -17,7 +17,7 @@ public enum SucessCode {
     UNFOLLOW_MEMBER(HttpStatus.OK, "언팔로우 성공", 2000),
     MEMBER_INFO(HttpStatus.OK, "사용자 정보 반환 성공", 2000),
     TOKEN_REISSUANCE(HttpStatus.OK, "토큰 재발행 성공", 2001),
-    MEMBER_UPDATE_SETTING(HttpStatus.OK, "계정 설정 업데이트 성공", 4015),
+    MEMBER_UPDATE_SETTING(HttpStatus.OK, "계정 설정 업데이트 성공", 2000),
     MEMBER_GET_SETTING(HttpStatus.OK, "계정 설정 불러오기 성공", 2000),
     MEMBER_GET_MYPAGE(HttpStatus.OK, "마이페이지 유저 정보 불러오기 성공", 2000),
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/config/WebSecurityConfig.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/config/WebSecurityConfig.java
@@ -86,7 +86,7 @@ public class WebSecurityConfig {
         configuration.addAllowedOrigin("http://oncounter.co.kr/");
         configuration.addAllowedOrigin("https://oncounter.co.kr/");
 
-        configuration.setAllowedMethods(Arrays.asList("GET","POST","PATCH","DELETE", "PUT"));
+        configuration.setAllowedMethods(Arrays.asList("GET","POST","PATCH","DELETE", "PUT", "OPTIONS"));
         configuration.addAllowedHeader("*");
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600L);

--- a/src/main/java/com/bluehair/hanghaefinalproject/config/WebSecurityConfig.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/config/WebSecurityConfig.java
@@ -79,7 +79,6 @@ public class WebSecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedOrigin("http://152.69.229.168:84/");
         configuration.addAllowedOrigin("http://d6y8g7dkunqrb.cloudfront.net/");
         configuration.addAllowedOrigin("https://d6y8g7dkunqrb.cloudfront.net/");

--- a/src/main/java/com/bluehair/hanghaefinalproject/config/WebSecurityConfig.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/config/WebSecurityConfig.java
@@ -79,6 +79,7 @@ public class WebSecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
+        configuration.addAllowedOrigin("http://localhost:3000");
         configuration.addAllowedOrigin("http://152.69.229.168:84/");
         configuration.addAllowedOrigin("http://d6y8g7dkunqrb.cloudfront.net/");
         configuration.addAllowedOrigin("https://d6y8g7dkunqrb.cloudfront.net/");


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
회원 정보(Nickname) 변경 후, 500 Error가 발생하는 현상입니다.
해당 현상의 원인은, Access Token이 최신화 되지 않은 상태로 페이지에 접근하게 되어 존재하지 않는 닉네임으로 접근을 시도하기 때문입니다
계정 설정 변경 시, Access Token 만료 메세지(4015)를 반환하도록 하였습니다.

추가적으로, 닉네임 변경 시 각 테이블에 존재하는 닉네임 역시 변경해주어야합니다.


## 작업사항
- `SuccessCode` 수정


## 변경로직
- 없음
