### PR TITLE
💎 Refactor data에 notification 대신 String 타입인 notificationContent를 전송

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/service/NotificationService.java
@@ -11,12 +11,9 @@ import com.bluehair.hanghaefinalproject.sse.repository.EmitterRepository;
 import com.bluehair.hanghaefinalproject.sse.repository.EmitterRepositoryImpl;
 import com.bluehair.hanghaefinalproject.sse.repository.NotificationRepository;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -70,9 +67,8 @@ public class NotificationService {
         sseEmitters.forEach(
                 (key, emitter) -> {
                     emitterRepository.saveEventCache(key, notification);
-                    Gson gson = new Gson();
-                    String data = gson.toJson(notification);
-                    sendToClient(emitter, key, data);
+
+                    sendToClient(emitter, key, notification.getContent());
                 }
         );
     }


### PR DESCRIPTION
프론트에서 실시간 알림 창을 띄우는 것이 아니기 때문에 실시간으로 알림 내용을 전해 줄 필요가 없다고 합니다.

## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
FE에서 실시간 알림창을 띄우는 방식이 아니기 때문에 해당 데이터를 삭제합니다.


## 작업사항
- 기존 ResponseNotificationDto로 보낸것을 String 타입인 notificationContent만 전송합니다. 


## 변경로직
- 내용을 적어주세요.
