### PR TITLE
🐞 BugFix: 회원 정보(nickname) 변경 시 변경 내역이 DB에 적용되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestRepository.java
@@ -20,4 +20,9 @@ public interface CollaboRequestRepository extends JpaRepository<CollaboRequest, 
     @Modifying
     @Query("DELETE from CollaboRequest c where c.post = :Post")
     void deleteAllByPost(@Param("Post") Post post);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE CollaboRequest c set c.nickname = :after where c.nickname = :nickname")
+    void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestRepository.java
@@ -23,6 +23,6 @@ public interface CollaboRequestRepository extends JpaRepository<CollaboRequest, 
 
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE CollaboRequest c set c.nickname = :after where c.nickname = :nickname")
+    @Query("UPDATE CollaboRequest c set c.nickname = :after where c.nickname = :before")
     void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentRepository.java
@@ -30,4 +30,5 @@ public interface CommentRepository {
     @Query("DELETE from Comment c where c.post = :Post")
     void deleteAllByPost(@Param("Post") Post post);
 
+    void updateNickname(String before, String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/JPACommentRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/JPACommentRepository.java
@@ -2,6 +2,14 @@ package com.bluehair.hanghaefinalproject.comment.repository;
 
 import com.bluehair.hanghaefinalproject.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface JPACommentRepository extends JpaRepository<Comment, Long>, CommentRepository {
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Comment c set c.nickname = :after where c.nickname = :nickname")
+    void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/JPACommentRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/JPACommentRepository.java
@@ -10,6 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 public interface JPACommentRepository extends JpaRepository<Comment, Long>, CommentRepository {
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Comment c set c.nickname = :after where c.nickname = :nickname")
+    @Query("UPDATE Comment c set c.nickname = :after where c.nickname = :before")
     void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.bluehair.hanghaefinalproject.member.service;
 
+import com.bluehair.hanghaefinalproject.collaboRequest.repository.CollaboRequestRepository;
+import com.bluehair.hanghaefinalproject.comment.repository.CommentRepository;
 import com.bluehair.hanghaefinalproject.common.exception.*;
 import com.bluehair.hanghaefinalproject.common.service.Validator;
 import com.bluehair.hanghaefinalproject.member.dto.responseDto.ResponseMemberInfoDto;
@@ -11,9 +13,12 @@ import com.bluehair.hanghaefinalproject.member.repository.FollowRepository;
 import com.bluehair.hanghaefinalproject.member.repository.JobRepository;
 import com.bluehair.hanghaefinalproject.member.repository.MemberDetailRepository;
 import com.bluehair.hanghaefinalproject.member.repository.MemberRepository;
+import com.bluehair.hanghaefinalproject.post.repository.PostRepository;
 import com.bluehair.hanghaefinalproject.security.CustomUserDetails;
 import com.bluehair.hanghaefinalproject.security.exception.CustomJwtException;
 import com.bluehair.hanghaefinalproject.security.jwt.JwtUtil;
+import com.bluehair.hanghaefinalproject.sse.repository.NotificationRepository;
+import com.bluehair.hanghaefinalproject.webSocket.repository.MessageRepository;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +47,11 @@ public class MemberService {
     private final MemberDetailRepository memberDetailRepository;
     private final JobRepository jobRepository;
 
+    private final MessageRepository messageRepository;
+    private final CollaboRequestRepository collaboRequestRepository;
+    private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepository;
+    private final PostRepository postRepository;
     @Transactional
     public void signUp(SignUpDto signUpDto) {
         memberRepository.findByEmail(signUpDto.getEmail())
@@ -208,6 +218,14 @@ public class MemberService {
 
         memberDetail.updateSettings(settingMemberDetailDto);
         memberDetailRepository.save(memberDetail);
+
+        if(settingMemberDto.getNickname() != null) {
+            messageRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
+            collaboRequestRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
+            commentRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
+            notificationRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
+            postRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
+        }
 
         jobRepository.deleteAllByMemberDetail(memberDetail);
         if (settingMemberDetailDto.getJobList() != null){

--- a/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/member/service/MemberService.java
@@ -212,6 +212,7 @@ public class MemberService {
 
         Member member = userDetails.getMember();
         MemberDetail memberDetail = member.getMemberDetail();
+        String before = member.getNickname();
 
         member.updateSetting(settingMemberDto);
         memberRepository.save(member);
@@ -220,11 +221,12 @@ public class MemberService {
         memberDetailRepository.save(memberDetail);
 
         if(settingMemberDto.getNickname() != null) {
-            messageRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
-            collaboRequestRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
-            commentRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
-            notificationRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
-            postRepository.updateNickname(userDetails.getMember().getNickname(), settingMemberDto.getNickname());
+            messageRepository.updateNickname(before, settingMemberDto.getNickname());
+            collaboRequestRepository.updateNickname(before, settingMemberDto.getNickname());
+            commentRepository.updateNickname(before, settingMemberDto.getNickname());
+            postRepository.updateNickname(before, settingMemberDto.getNickname());
+
+            notificationRepository.updateNickname(before, settingMemberDto.getNickname());
         }
 
         jobRepository.deleteAllByMemberDetail(memberDetail);

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/repository/JPAPostRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/repository/JPAPostRepository.java
@@ -2,7 +2,14 @@ package com.bluehair.hanghaefinalproject.post.repository;
 
 import com.bluehair.hanghaefinalproject.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface JPAPostRepository extends JpaRepository<Post, Long>, PostRepository {
-
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Post p set p.nickname = :after where p.nickname = :nickname")
+    void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/repository/JPAPostRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/repository/JPAPostRepository.java
@@ -10,6 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 public interface JPAPostRepository extends JpaRepository<Post, Long>, PostRepository {
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Post p set p.nickname = :after where p.nickname = :nickname")
+    @Query("UPDATE Post p set p.nickname = :after where p.nickname = :before")
     void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/repository/PostRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.bluehair.hanghaefinalproject.post.repository;
 
 import com.bluehair.hanghaefinalproject.post.entity.Post;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -16,4 +17,5 @@ public interface PostRepository {
     List<Post> findByContentsContains(Pageable pageable, String search);
     List<Post> findByNickname(Pageable pageable,String nickname);
     void deleteById(Long postId);
+    void updateNickname(String before, String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/repository/NotificationRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/repository/NotificationRepository.java
@@ -19,6 +19,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Notification n set n.sender = :after where n.sender = :nickname")
+    @Query("UPDATE Notification n set n.sender = :after where n.sender = :before")
     void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/sse/repository/NotificationRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/sse/repository/NotificationRepository.java
@@ -3,7 +3,9 @@ package com.bluehair.hanghaefinalproject.sse.repository;
 import com.bluehair.hanghaefinalproject.member.entity.Member;
 import com.bluehair.hanghaefinalproject.sse.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -14,4 +16,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Transactional
     @Query("SELECT COUNT(n) from Notification n where n.receiver.nickname =:nickname and n.isRead = false")
     Long countUnreadNotifications(String nickname);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification n set n.sender = :after where n.sender = :nickname")
+    void updateNickname(@Param("before") String before, @Param("after") String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/webSocket/repository/MessageRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/webSocket/repository/MessageRepository.java
@@ -2,6 +2,10 @@ package com.bluehair.hanghaefinalproject.webSocket.repository;
 
 import com.bluehair.hanghaefinalproject.webSocket.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -9,5 +13,9 @@ public interface MessageRepository extends JpaRepository<ChatMessage, Long> {
 
     List<ChatMessage> findByChatRoom_RoomIdOrderByCreatedAtDesc(Long roomId);
 
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ChatMessage c set c.nickname = :after where c.nickname = :nickname")
+    void updateNickname(@Param("before") String before, @Param("after") String after);
 }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/webSocket/repository/MessageRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/webSocket/repository/MessageRepository.java
@@ -15,7 +15,7 @@ public interface MessageRepository extends JpaRepository<ChatMessage, Long> {
 
     @Transactional
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE ChatMessage c set c.nickname = :after where c.nickname = :nickname")
+    @Query("UPDATE ChatMessage c set c.nickname = :after where c.nickname = :before")
     void updateNickname(@Param("before") String before, @Param("after") String after);
 }
 


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
회원 정보(nickname) 변경 시 변경 내역이 DB에 적용되지 않는 문제 수정하였습니다.
수정 방향은 다음과 같습니다.
1. Nickname 컬럼을 지니는 테이블 확인
2. 확인된 테이블의 Repository에 닉네임 변경 로직 구현
3. Member Service에서 각 Repository 의존 및 메소드 호출

## 작업사항
- 닉네임 컬럼 변경 메소드 구현
- Member Service 반영


## 변경로직
- 없음

close #255 
