### PR TITLE
🐞 BugFix: 음원 합성 로직의 Transaction 분리

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/post/controller/PostController.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/controller/PostController.java
@@ -64,14 +64,10 @@ public class PostController {
                                                               @Parameter(description = "WAV 및 2 Channel 오디오만 지원합니다.")
                                                               @RequestPart(value = "musicFile") List<MultipartFile> musicFileList,
                                                               @AuthenticationPrincipal CustomUserDetails userDetails) throws UnsupportedAudioFileException, IOException {
-        return SuccessResponse.toResponseEntity(CREATE_POST,
-                postServiceFacade.createPost(
-                        userDetails,
-                        requestCreatePostDto.toPostDto(),
-                        requestCreatePostDto.toCollaboRequestDetailsDto(),
-                        requestCreatePostDto.toMusicPartList(),
-                        musicFileList
-                        ));
+        Long collaboRequestId = postServiceFacade.createPost(userDetails, requestCreatePostDto.toPostDto(),
+                requestCreatePostDto.toCollaboRequestDetailsDto(), requestCreatePostDto.toMusicPartList(), musicFileList);
+        postServiceFacade.approveCollaboRequest(collaboRequestId, userDetails);
+        return SuccessResponse.toResponseEntity(CREATE_POST, null);
     }
     @Tag(name = "Post")
     @Operation(summary = "게시글 수정", description = "게시글 수정")

--- a/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostServiceFacade.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/post/service/PostServiceFacade.java
@@ -25,13 +25,17 @@ public class PostServiceFacade {
 
     @Transactional
     public Long createPost(CustomUserDetails userDetails, PostDto postDto, CollaboRequestDetailsDto collaboRequestDetailsDto,
-                           List<String> musicPartList, List<MultipartFile> musicFileList) throws UnsupportedAudioFileException, IOException {
+                           List<String> musicPartList, List<MultipartFile> musicFileList) {
         Long postId = postService.createPost(postDto, userDetails.getMember().getNickname());
         Long collaboRequestId = collaboRequestService.collaboRequest(postId, collaboRequestDetailsDto, userDetails.getMember());
         musicService.saveMusic(musicFileList, postId, musicPartList, collaboRequestId);
 
+        return collaboRequestId;
+    }
+
+    @Transactional
+    public void approveCollaboRequest(Long collaboRequestId, CustomUserDetails userDetails) throws UnsupportedAudioFileException, IOException {
         collaboRequestService.approveCollaboRequest(collaboRequestId, userDetails.getMember());
         musicService.mixMusic(collaboRequestId);
-        return postId;
     }
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
음원 업로드가 정상적으로 진행되지 않는 오류입니다.
확인 결과, 하나의 Transaction에서 음원의 합성과 등록을 처리하다보니, 음원의 등록이 끝나지 않은 상태에서 합성을 진행하려고 하는 것이 원인이었습니다.
이에 따라, 두 기능의 Transaction을 분리하였습니다.


## 작업사항
- 음원 합성 로직의 Transaction 분리


## 변경로직
- 음원 합성 로직의 Transaction 분리

close #300 
