### PR TITLE
🐞 BugFix: saveMessageDto -> ChatMessage 변환 로직 수정

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/webSocket/repository/MessageRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/webSocket/repository/MessageRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface MessageRepository extends JpaRepository<ChatMessage, Long> {
 
-    List<ChatMessage> findByChatRoom_RoomIdOrderByCreatedAtDesc(Long roomId);
+    List<ChatMessage> findByChatRoom_RoomIdOrderByCreatedAtAsc(Long roomId);
 
     @Transactional
     @Modifying(clearAutomatically = true)

--- a/src/main/java/com/bluehair/hanghaefinalproject/webSocket/service/MessageService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/webSocket/service/MessageService.java
@@ -7,7 +7,9 @@ import com.bluehair.hanghaefinalproject.member.repository.MemberRepository;
 import com.bluehair.hanghaefinalproject.webSocket.dto.service.MessageDto;
 import com.bluehair.hanghaefinalproject.webSocket.dto.service.SaveMessageDto;
 import com.bluehair.hanghaefinalproject.webSocket.entity.ChatMessage;
+import com.bluehair.hanghaefinalproject.webSocket.entity.ChatRoom;
 import com.bluehair.hanghaefinalproject.webSocket.repository.MessageRepository;
+import com.bluehair.hanghaefinalproject.webSocket.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ public class MessageService {
     private final MemberRepository memberRepository;
 
     private final MessageRepository messageRepository;
+    private final RoomRepository roomRepository;
 
     public SaveMessageDto saveMessage(Long roomId, MessageDto messageDto, String nickname) {
 
@@ -34,7 +37,17 @@ public class MessageService {
         SaveMessageDto saveMessageDto = new SaveMessageDto(roomId, messageDto.getMessage(), member.getNickname(), member.getProfileImg()
                                                             ,messageDto.getDate(), messageDto.getTime());
 
-        ChatMessage chatMessage = MESSAGE_MAPPER.SaveMessageDtoToMessage(saveMessageDto);
+        ChatRoom chatRoom = roomRepository.findById(roomId)
+                .orElseThrow(()-> new RuntimeException("존재하지 않는 ChatRoom"));
+
+        ChatMessage chatMessage = ChatMessage.builder()
+                .message(saveMessageDto.getMessage())
+                .profileImg(saveMessageDto.getProfileImg())
+                .time(saveMessageDto.getTime())
+                .nickname(saveMessageDto.getNickname())
+                .chatRoom(chatRoom)
+                .date(saveMessageDto.getDate())
+                .build();
 
         messageRepository.save(chatMessage);
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/webSocket/service/RoomService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/webSocket/service/RoomService.java
@@ -90,7 +90,7 @@ public class RoomService {
     @Transactional
     public List<ResponseMessageDto> entranceRoom(Long roomId) {
 
-        List<ChatMessage> message = messageRepository.findByChatRoom_RoomIdOrderByCreatedAtDesc(roomId);
+        List<ChatMessage> message = messageRepository.findByChatRoom_RoomIdOrderByCreatedAtAsc(roomId);
         List<ResponseMessageDto> messageList = new ArrayList<>();
         for (ChatMessage m : message){
             ResponseMessageDto messageListDto = new ResponseMessageDto(m.getMessage(), m.getNickname(), m.getProfileImg(), m.getDate(), m.getTime());

--- a/src/main/java/com/bluehair/hanghaefinalproject/webSocket/service/RoomService.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/webSocket/service/RoomService.java
@@ -87,6 +87,7 @@ public class RoomService {
         return roomIdDto;
     }
 
+    @Transactional
     public List<ResponseMessageDto> entranceRoom(Long roomId) {
 
         List<ChatMessage> message = messageRepository.findByChatRoom_RoomIdOrderByCreatedAtDesc(roomId);


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Database에 정상적으로 `Room ID`가 저장되지 않는 현상을 발견했습니다.
`SaveMessageDto` -> `ChatMessage` 변환 과정에서 `ChatRoom` Entity가 아닌 `ChatRoomId`를 사용해 변환을 하려고 시도했던 것을 확인했습니다. 이에 따라 우선적으로 빌더 패턴을 사용해서 값이 정상적으로 반영될 수 있도록 해두었습니다.

@GGONG1956 추후 MapStruct를 사용하는 패턴으로 변경해주시면 감사하겠습니다.

## 작업사항
- `MessageService`의 `SaveMessage` Method 로직 변경


## 변경로직
- PR 설명 참고
