### PR TITLE
✨ Feat: Comment, CollaboRequest 도메인 QueryDSL 적용

### DIFF
--- a/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestCustomRepositoryImpl.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/collaboRequest/repository/CollaboRequestCustomRepositoryImpl.java
@@ -18,7 +18,7 @@ public class CollaboRequestCustomRepositoryImpl implements CollaboRequestCustomR
     @Override
     public List<CollaboRequest> findAllByPostId(Long id) {
         return jpaQueryFactory.selectFrom(collaboRequest)
-                .where(collaboRequest.id.eq(id))
+                .where(collaboRequest.post.id.eq(id))
                 .fetch();
     }
 

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentCustomRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentCustomRepository.java
@@ -1,32 +1,9 @@
 package com.bluehair.hanghaefinalproject.comment.repository;
 
-import com.bluehair.hanghaefinalproject.comment.entity.Comment;
 import com.bluehair.hanghaefinalproject.post.entity.Post;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface CommentCustomRepository {
-    Comment save(Comment comment);
-
-    Optional<Comment> findById(Long postId);
-
-    void deleteById(Long commentId);
-
-    List<Comment> findByParentsId(Long parentsId);
-
-    List<Comment> findByPostId(Long postId);
-
-    List<Comment> findByPostIdAndParentsId(Long postId, Long parentsId);
-
-    @Transactional
-    @Modifying
-    @Query("DELETE from Comment c where c.post = :Post")
     void deleteAllByPost(@Param("Post") Post post);
-
     void updateNickname(String before, String after);
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentCustomRepositoryImpl.java
@@ -21,54 +21,6 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository{
     private final EntityManager em;
 
     @Override
-    public Comment save(Comment comment) {
-        em.persist(comment);
-        return comment;
-    }
-
-    @Override
-    public Optional<Comment> findById(Long postId) {
-        Comment comment1 = jpaQueryFactory.select(comment)
-                .from(comment)
-                .where(comment.post.id.eq(postId))
-                .fetchOne();
-        return Optional.ofNullable(comment1);
-    }
-
-    @Override
-    public void deleteById(Long commentId) {
-        jpaQueryFactory
-                .delete(comment)
-                .where(comment.id.eq(commentId))
-                .execute();
-
-    }
-
-    @Override
-    public List<Comment> findByParentsId(Long parentsId) {
-        return jpaQueryFactory
-                .select(comment)
-                .where(comment.parentsId.eq(parentsId))
-                .fetch();
-    }
-
-    @Override
-    public List<Comment> findByPostId(Long postId) {
-        return jpaQueryFactory
-                .select(comment)
-                .where(comment.post.id.eq(postId))
-                .fetch();
-    }
-
-    @Override
-    public List<Comment> findByPostIdAndParentsId(Long postId, Long parentsId) {
-        return jpaQueryFactory
-                .select(comment)
-                .where(comment.post.id.eq(postId).and(comment.parentsId.eq(parentsId)))
-                .fetch();
-    }
-
-    @Override
     public void deleteAllByPost(Post post) {
         jpaQueryFactory
                 .delete(comment)

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/CommentRepository.java
@@ -3,6 +3,6 @@ package com.bluehair.hanghaefinalproject.comment.repository;
 import org.springframework.stereotype.Component;
 
 @Component
-public interface CommentRepository extends CommentCustomRepository {
+public interface CommentRepository extends CommentCustomRepository, JPACommentRepository {
 
 }

--- a/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/JPACommentRepository.java
+++ b/src/main/java/com/bluehair/hanghaefinalproject/comment/repository/JPACommentRepository.java
@@ -2,14 +2,20 @@ package com.bluehair.hanghaefinalproject.comment.repository;
 
 import com.bluehair.hanghaefinalproject.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
-public interface JPACommentRepository extends JpaRepository<Comment, Long>, CommentRepository {
-    @Transactional
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Comment c set c.nickname = :after where c.nickname = :before")
-    void updateNickname(@Param("before") String before, @Param("after") String after);
+import java.util.List;
+import java.util.Optional;
+
+public interface JPACommentRepository extends JpaRepository<Comment, Long> {
+    Comment save(Comment comment);
+
+    Optional<Comment> findById(Long postId);
+
+    void deleteById(Long commentId);
+
+    List<Comment> findByParentsId(Long parentsId);
+
+    List<Comment> findByPostId(Long postId);
+
+    List<Comment> findByPostIdAndParentsId(Long postId, Long parentsId);
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐞 BugFix
✨ Feat
📝 Doc
💎 Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
Comment 도메인에 QueryDSL을 적용 및 CollaboRequest 오류 조치.
![image](https://user-images.githubusercontent.com/72681875/217471210-d8cf8ab8-6014-4d2e-9dc3-3cf52c12403d.png)
Repository(interface) 가 JpaRepository(interface), CustomRepository(interface)를 다중 상속 받고,
→ CustomRepository 인터페이스에 선언되어 있는 메소드에 대한 구현은 RepositoryImpl 에서 한다.
→ 그리고 사용자는 Repository 인터페이스를 DI 받아서 사용한다.

## 작업사항
-  Comment 도메인 QueryDSL 적용
- CollaboRequest 오류 조치


## 변경로직
- `Repository <- JPARepository 의존`에서 `Repository -> JPARepository, CustomRepository 의존`으로 변경
